### PR TITLE
fix(tests): correct stripeClient mock path in integration tests

### DIFF
--- a/tests/integration/e2e/errorPaths.test.ts
+++ b/tests/integration/e2e/errorPaths.test.ts
@@ -30,7 +30,7 @@ jest.mock('@/queue/producers', () => ({
   enqueueCheckout: jest.fn().mockResolvedValue(undefined),
 }));
 
-jest.mock('@/payments/stripeClient', () => ({
+jest.mock('@/payments/providers/stripe/stripeClient', () => ({
   getStripeClient: () => ({ webhooks: { constructEvent: jest.fn() } }),
 }));
 

--- a/tests/integration/e2e/happyPath.test.ts
+++ b/tests/integration/e2e/happyPath.test.ts
@@ -26,7 +26,7 @@ jest.mock('@/queue/producers', () => ({
   enqueueCheckout: jest.fn().mockResolvedValue(undefined),
 }));
 
-jest.mock('@/payments/stripeClient', () => ({
+jest.mock('@/payments/providers/stripe/stripeClient', () => ({
   getStripeClient: () => ({
     issuing: {
       cardholders: { create: jest.fn().mockResolvedValue({ id: 'ich_test' }) },


### PR DESCRIPTION
Fixes #56

## Problem

`happyPath.test.ts` and `errorPaths.test.ts` both mocked `@/payments/stripeClient`, which doesn't exist. Jest failed to resolve it and crashed the entire test suite before any test ran.

## Fix

Updated the two mock paths to point to the actual module location:

```diff
- jest.mock('@/payments/stripeClient', ...)
+ jest.mock('@/payments/providers/stripe/stripeClient', ...)
```

## Note

The related `providerFactory.test.ts` failure (`resetPaymentProvider is not a function`) is resolved separately by merging PR #55, which adds that export.