### PR TITLE
feat(orchestrator): auto-cancel card and return funds on intent expiry (#46)

### DIFF
--- a/src/orchestrator/intentService.ts
+++ b/src/orchestrator/intentService.ts
@@ -80,6 +80,8 @@ async function cleanupExpiredIntent(intentId: string): Promise<void> {
 
 export async function expireIntent(intentId: string): Promise<TransitionResult> {
   const result = await transitionIntent(intentId, IntentEvent.INTENT_EXPIRED);
-  await cleanupExpiredIntent(intentId);
+  await cleanupExpiredIntent(intentId).catch((err) => {
+    console.error({ intentId, err }, 'Failed to run expiry cleanup');
+  });
   return result;
 }

--- a/tests/unit/orchestrator/expireCleanup.test.ts
+++ b/tests/unit/orchestrator/expireCleanup.test.ts
@@ -101,4 +101,10 @@ describe('expireIntent cleanup', () => {
 
     expect(mockReturnIntent).not.toHaveBeenCalled();
   });
+
+  it('resolves when a Prisma lookup inside cleanup throws', async () => {
+    (mockPrisma.virtualCard.findUnique as jest.Mock).mockRejectedValue(new Error('DB connection lost'));
+
+    await expect(expireIntent('intent-1')).resolves.toEqual(mockTransitionResult);
+  });
 });


### PR DESCRIPTION
## Summary

- `expireIntent()` now calls a new `cleanupExpiredIntent()` helper after transitioning state
- Cancels the Stripe virtual card if one was issued for the intent
- Returns reserved ledger pot funds if an active pot exists
- Both operations are best-effort — errors are logged but never propagate, so expiry always succeeds

Closes #46 

## Test plan

- [x] `npm test -- --testPathPattern=expireCleanup` — 6 unit tests covering: card+pot, card only, neither, `cancelCard` throws, `returnIntent` throws, settled pot ignored
- [x] `npm test` — full unit suite stays green