### PR TITLE
fix(payments): replace deprecated Stripe authorization approve endpoint

### DIFF
--- a/src/contracts/services.ts
+++ b/src/contracts/services.ts
@@ -20,7 +20,7 @@ export interface IPaymentProvider {
   revealCard(intentId: string): Promise<CardReveal>;
   freezeCard(intentId: string): Promise<void>;
   cancelCard(intentId: string): Promise<void>;
-  handleWebhookEvent(rawBody: Buffer | string, signature: string): Promise<void>;
+  handleWebhookEvent(rawBody: Buffer | string, signature: string): Promise<Record<string, unknown>>;
   getIssuingBalance(currency: string): Promise<IssuingBalance>;
 }
 

--- a/src/payments/providers/mock/mockProvider.ts
+++ b/src/payments/providers/mock/mockProvider.ts
@@ -46,8 +46,9 @@ export class MockPaymentProvider implements IPaymentProvider {
     this.calls.push({ method: 'cancelCard', args: [intentId], timestamp: Date.now() });
   }
 
-  async handleWebhookEvent(rawBody: Buffer | string, signature: string): Promise<void> {
+  async handleWebhookEvent(rawBody: Buffer | string, signature: string): Promise<Record<string, unknown>> {
     this.calls.push({ method: 'handleWebhookEvent', args: [rawBody, signature], timestamp: Date.now() });
+    return { received: true };
   }
 
   async getIssuingBalance(currency: string): Promise<IssuingBalance> {

--- a/src/payments/providers/stripe/index.ts
+++ b/src/payments/providers/stripe/index.ts
@@ -25,7 +25,7 @@ export class StripePaymentProvider implements IPaymentProvider {
     return cancelCard(intentId);
   }
 
-  async handleWebhookEvent(rawBody: Buffer | string, signature: string): Promise<void> {
+  async handleWebhookEvent(rawBody: Buffer | string, signature: string): Promise<Record<string, unknown>> {
     return handleStripeEvent(rawBody, signature);
   }
 

--- a/src/payments/providers/stripe/webhookHandler.ts
+++ b/src/payments/providers/stripe/webhookHandler.ts
@@ -2,7 +2,7 @@ import Stripe from 'stripe';
 import { getStripeClient } from './stripeClient';
 import { prisma } from '@/db/client';
 
-export async function handleStripeEvent(rawBody: Buffer | string, signature: string): Promise<void> {
+export async function handleStripeEvent(rawBody: Buffer | string, signature: string): Promise<Record<string, unknown>> {
   const stripe = getStripeClient();
   const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
   if (!webhookSecret) throw new Error('STRIPE_WEBHOOK_SECRET not set');
@@ -19,15 +19,12 @@ export async function handleStripeEvent(rawBody: Buffer | string, signature: str
 
   switch (event.type) {
     case 'issuing_authorization.request': {
-      // MUST respond within 2 seconds — auto-approve in test mode
+      // Return { approved: true } in the response body — the approve/decline
+      // endpoints are deprecated; Stripe now reads the decision from the HTTP
+      // response body within the 2-second window.
       const auth = event.data.object as Stripe.Issuing.Authorization;
-      try {
-        await stripe.issuing.authorizations.approve(auth.id);
-      } catch (err) {
-        console.error(JSON.stringify({ level: 'error', message: 'Failed to approve authorization', error: String(err), intentId }));
-      }
       await logAuditEvent(intentId, 'STRIPE_AUTHORIZATION_REQUEST', { authId: auth.id, amount: auth.amount });
-      break;
+      return { approved: true };
     }
 
     case 'issuing_authorization.created': {
@@ -45,6 +42,8 @@ export async function handleStripeEvent(rawBody: Buffer | string, signature: str
     default:
       console.log(JSON.stringify({ level: 'info', message: 'Unhandled Stripe event', type: event.type }));
   }
+
+  return { received: true };
 }
 
 async function logAuditEvent(intentId: string, eventName: string, payload: Record<string, unknown>): Promise<void> {


### PR DESCRIPTION
Closes #64

## Summary

- `stripe.issuing.authorizations.approve()` is deprecated and returns 404
- Stripe now reads the approve/decline decision from the HTTP **response body** (`{ approved: true/false }`) within the 2-second synchronous window
- Updated `handleWebhookEvent` return type from `Promise<void>` to `Promise<Record<string, unknown>>` in the contract, Stripe provider, and mock provider
- `issuing_authorization.request` handler now returns `{ approved: true }` directly

## Files changed

- `src/payments/providers/stripe/webhookHandler.ts`
- `src/contracts/services.ts`
- `src/payments/providers/stripe/index.ts`
- `src/payments/providers/mock/mockProvider.ts`

## Test plan

- [ ] `npm test -- --testPathPattern=webhookHandler` passes
- [ ] `npm test -- --testPathPattern=mockProvider` passes