### PR TITLE
fix(api): add Stripe-Version response header to webhook responses

### DIFF
--- a/src/api/routes/webhooks.ts
+++ b/src/api/routes/webhooks.ts
@@ -17,14 +17,17 @@ export async function webhookRoutes(fastify: FastifyInstance): Promise<void> {
       return reply.status(400).send({ error: 'Missing stripe-signature header' });
     }
 
+    let response: Record<string, unknown> = { received: true };
     try {
       const body = request.body as Buffer | string;
-      await getPaymentProvider().handleWebhookEvent(body, signature);
+      response = await getPaymentProvider().handleWebhookEvent(body, signature);
     } catch (err) {
       // Log but always return 200 to Stripe to prevent retries
       fastify.log.error({ message: 'Stripe webhook processing error', error: String(err) });
     }
 
-    return reply.send({ received: true });
+    // Stripe requires the Stripe-Version header in responses to issuing_authorization.request.
+    // Without it Stripe reports "Invalid Stripe API version: " and declines the authorization.
+    return reply.header('Stripe-Version', '2024-06-20').send(response);
   });
 }


### PR DESCRIPTION
Closes #65

## Summary

- Stripe's real-time authorization requires the response to include a `Stripe-Version` header
- Without it Stripe reports `webhook_error: "Invalid Stripe API version: "` and declines every authorization regardless of the response body
- Added `reply.header('Stripe-Version', '2024-06-20')` to the webhook route
- Also forwards the response body returned by `handleWebhookEvent` to the HTTP response (required for `{ approved: true }` to reach Stripe)

> **Note:** depends on #64 for the `handleWebhookEvent` return type change. Merge #64 first.

## Files changed

- `src/api/routes/webhooks.ts`

## Test plan

- [ ] `npm test -- --testPathPattern=stripeWebhook` passes
- [ ] `npm test -- --testPathPattern=wiring` passes