### PR TITLE
fix(api): remove worker API key from Redis rate-limit key

### DIFF
--- a/src/api/routes/agent.ts
+++ b/src/api/routes/agent.ts
@@ -141,9 +141,8 @@ export async function agentRoutes(fastify: FastifyInstance): Promise<void> {
         max: 2,
         timeWindow: '1 minute',
         keyGenerator: (req: FastifyRequest) => {
-          const workerKey = req.headers['x-worker-key'] ?? '';
           const intentId = (req.params as { intentId: string }).intentId ?? '';
-          return `${workerKey}:${intentId}`;
+          return `card-reveal:${intentId}`;
         },
       },
     },

--- a/tests/unit/api/rateLimit.test.ts
+++ b/tests/unit/api/rateLimit.test.ts
@@ -359,7 +359,7 @@ describe('Per-route: POST /v1/agent/register (max 3 per IP)', () => {
 
 // ─── Per-route: GET /v1/agent/card/:intentId (max 2) ────────────────────────
 
-describe('Per-route: GET /v1/agent/card/:intentId (max 2 per worker-key:intentId)', () => {
+describe('Per-route: GET /v1/agent/card/:intentId (max 2 per intentId)', () => {
   it('returns 429 after 2 requests with same worker-key and intentId', async () => {
     const ip = '10.4.0.1';
     const responses = await fireRequests('GET', '/v1/agent/card/intent-card-rl', 3, {


### PR DESCRIPTION
## Summary

- The card reveal endpoint `GET /v1/agent/card/:intentId` was using the raw `X-Worker-Key` header value as part of its Redis rate-limit key
- This wrote `WORKER_API_KEY` into Redis on every request — up to 120 times per checkout — where anyone with `SCAN`/`KEYS` access could read it
- The worker key adds no isolation value (all workers share the same secret), so the key is now `card-reveal:<intentId>` instead of `<workerKey>:<intentId>`

## Test plan

- [ ] `npm test -- --testPathPattern=rateLimit` — all 9 tests pass
- [ ] `npm test -- --testPathPattern=wiring` — all 49 tests pass
- [ ] Rate-limit behaviour (max 2 req/min per intentId) is unchanged

Fixes #60