### PR TITLE
feat(payments): ledger-to-Stripe reconciliation on transaction capture

### DIFF
--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -7,3 +7,4 @@ export * from './audit';
 export * from './errors';
 export * from './services';
 export * from './agent';
+export * from './reconciliation';

--- a/src/contracts/reconciliation.ts
+++ b/src/contracts/reconciliation.ts
@@ -1,0 +1,16 @@
+export interface ReconciliationReport {
+  intentId: string;
+  internal: {
+    reserved: number;
+    settled: number;
+    potStatus: string | null;
+    ledgerEntries: string[]; // e.g. ["RESERVE:5000", "SETTLE:3500"]
+  };
+  stripe: {
+    cardStatus: string;
+    transactions: Array<{ id: string; amount: number; type: string }>;
+    totalCaptured: number;
+  } | null; // null if no VirtualCard exists for this intent
+  inSync: boolean;
+  discrepancies: string[];
+}

--- a/src/payments/providers/stripe/reconciliationService.ts
+++ b/src/payments/providers/stripe/reconciliationService.ts
@@ -1,0 +1,45 @@
+import { getStripeClient } from './stripeClient';
+import { prisma } from '@/db/client';
+import type { ReconciliationReport } from '@/contracts';
+
+export async function reconcileIntent(intentId: string): Promise<ReconciliationReport> {
+  const pot = await prisma.pot.findUnique({ where: { intentId } });
+  const entries = await prisma.ledgerEntry.findMany({ where: { intentId } });
+  const card = await prisma.virtualCard.findUnique({ where: { intentId } });
+
+  const internal = {
+    reserved: pot?.reservedAmount ?? 0,
+    settled: pot?.settledAmount ?? 0,
+    potStatus: pot?.status ?? null,
+    ledgerEntries: entries.map(e => `${e.type}:${e.amount}`),
+  };
+
+  if (!card) {
+    return { intentId, internal, stripe: null, inSync: true, discrepancies: [] };
+  }
+
+  const stripe = getStripeClient();
+  const stripeCard = await stripe.issuing.cards.retrieve(card.stripeCardId);
+  const txList = await stripe.issuing.transactions.list({
+    card: card.stripeCardId,
+    type: 'capture',
+  });
+
+  const totalCaptured = txList.data.reduce((sum, t) => sum + t.amount, 0);
+  const stripeReport = {
+    cardStatus: stripeCard.status,
+    transactions: txList.data.map(t => ({ id: t.id, amount: t.amount, type: t.type })),
+    totalCaptured,
+  };
+
+  const discrepancies: string[] = [];
+  if (pot !== null && pot.settledAmount !== totalCaptured) {
+    discrepancies.push(`settledAmount ${pot.settledAmount} != stripe captured ${totalCaptured}`);
+  }
+  const expectedCardStatus = (pot?.status === 'SETTLED' || pot?.status === 'RETURNED') ? 'canceled' : 'active';
+  if (stripeCard.status !== expectedCardStatus) {
+    discrepancies.push(`pot status ${pot?.status} expects card ${expectedCardStatus} but got ${stripeCard.status}`);
+  }
+
+  return { intentId, internal, stripe: stripeReport, inSync: discrepancies.length === 0, discrepancies };
+}

--- a/src/payments/providers/stripe/webhookHandler.ts
+++ b/src/payments/providers/stripe/webhookHandler.ts
@@ -1,6 +1,7 @@
 import Stripe from 'stripe';
 import { getStripeClient } from './stripeClient';
 import { prisma } from '@/db/client';
+import { reconcileIntent } from './reconciliationService';
 
 export async function handleStripeEvent(rawBody: Buffer | string, signature: string): Promise<Record<string, unknown>> {
   const stripe = getStripeClient();
@@ -36,6 +37,14 @@ export async function handleStripeEvent(rawBody: Buffer | string, signature: str
     case 'issuing_transaction.created': {
       const txn = event.data.object as Stripe.Issuing.Transaction;
       await logAuditEvent(intentId, 'STRIPE_TRANSACTION_CREATED', { transactionId: txn.id, amount: txn.amount });
+      // Fire-and-forget reconciliation — discrepancy failure must not break webhook
+      reconcileIntent(intentId).then(async (report) => {
+        if (!report.inSync) {
+          await logAuditEvent(intentId, 'RECONCILIATION_DISCREPANCY', { discrepancies: report.discrepancies, report });
+        }
+      }).catch((err) => {
+        console.error(JSON.stringify({ level: 'error', message: 'Reconciliation failed', intentId, error: String(err) }));
+      });
       break;
     }
 

--- a/tests/integration/stripe/reconciliation.test.ts
+++ b/tests/integration/stripe/reconciliation.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Integration test — Ledger-to-Stripe reconciliation
+ *
+ * Requires STRIPE_SECRET_KEY (real test-mode key) and a running PostgreSQL
+ * instance (docker compose up -d).
+ *
+ * Run with:
+ *   npm run test:integration -- --testPathPattern=reconciliation
+ */
+
+import Stripe from 'stripe';
+import { prisma } from '@/db/client';
+import { reconcileIntent } from '@/payments/providers/stripe/reconciliationService';
+
+const STRIPE_KEY = process.env.STRIPE_SECRET_KEY;
+const describeIfStripe = STRIPE_KEY && !STRIPE_KEY.includes('placeholder')
+  ? describe
+  : describe.skip;
+
+let stripe: Stripe;
+let cardId: string;
+let intentId: string;
+let userId: string;
+
+describeIfStripe('Reconciliation integration', () => {
+  beforeAll(async () => {
+    stripe = new Stripe(STRIPE_KEY!, { apiVersion: '2024-06-20' as Stripe.LatestApiVersion });
+
+    // Create minimal DB records
+    const user = await prisma.user.create({
+      data: { email: `recon-test-${Date.now()}@example.com`, telegramChatId: null, stripeCardholderId: null },
+    });
+    userId = user.id;
+
+    const intent = await prisma.purchaseIntent.create({
+      data: {
+        userId,
+        query: 'reconciliation test product',
+        maxBudget: 5000,
+        currency: 'gbp',
+        status: 'DONE',
+      },
+    });
+    intentId = intent.id;
+
+    // Create Stripe cardholder and card
+    const cardholder = await stripe.issuing.cardholders.create({
+      name: 'Recon Test',
+      email: `recon-stripe-${Date.now()}@example.com`,
+      phone_number: '+15555555555',
+      type: 'individual',
+      individual: {
+        first_name: 'Recon',
+        last_name: 'Test',
+        dob: { day: 1, month: 1, year: 1980 },
+      },
+      billing: {
+        address: { line1: '1 Test St', city: 'London', postal_code: 'EC1A 1BB', country: 'GB' },
+      },
+    });
+
+    const card = await stripe.issuing.cards.create({
+      cardholder: cardholder.id,
+      currency: 'eur',
+      type: 'virtual',
+      status: 'active',
+      spending_controls: {
+        spending_limits: [{ amount: 5000, interval: 'per_authorization' }],
+      },
+      metadata: { intentId },
+    });
+    cardId = card.id;
+
+    // Write VirtualCard to DB
+    await prisma.virtualCard.create({
+      data: { intentId, stripeCardId: cardId, last4: card.last4 },
+    });
+
+    // Simulate a capture
+    const auth = await stripe.testHelpers.issuing.authorizations.create({
+      card: cardId,
+      amount: 3500,
+      currency: 'eur',
+      merchant_data: { name: 'Test Merchant' },
+    });
+    await stripe.testHelpers.issuing.authorizations.capture(auth.id);
+
+    // Cancel the card (mirrors what the system does post-checkout)
+    await stripe.issuing.cards.update(cardId, { status: 'canceled' });
+
+    // Write matching ledger records
+    await prisma.pot.create({
+      data: { intentId, reservedAmount: 5000, settledAmount: 3500, status: 'SETTLED' },
+    });
+    await prisma.ledgerEntry.create({
+      data: { intentId, type: 'RESERVE', amount: 5000 },
+    });
+    await prisma.ledgerEntry.create({
+      data: { intentId, type: 'SETTLE', amount: 3500 },
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    // Clean up DB records (cascade delete via purchaseIntent)
+    await prisma.purchaseIntent.delete({ where: { id: intentId } }).catch(() => {});
+    await prisma.user.delete({ where: { id: userId } }).catch(() => {});
+    await prisma.$disconnect();
+  });
+
+  it('returns inSync:true when ledger matches Stripe captured amount', async () => {
+    const report = await reconcileIntent(intentId);
+
+    expect(report.inSync).toBe(true);
+    expect(report.discrepancies).toHaveLength(0);
+    expect(report.stripe).not.toBeNull();
+    expect(report.stripe?.totalCaptured).toBeGreaterThan(0);
+  });
+
+  it('returns inSync:false with discrepancy when settledAmount is wrong', async () => {
+    // Corrupt the pot
+    await prisma.pot.update({
+      where: { intentId },
+      data: { settledAmount: 9999 },
+    });
+
+    const report = await reconcileIntent(intentId);
+
+    expect(report.inSync).toBe(false);
+    expect(report.discrepancies.some(d => d.includes('9999'))).toBe(true);
+
+    // Restore
+    await prisma.pot.update({
+      where: { intentId },
+      data: { settledAmount: 3500 },
+    });
+  });
+});

--- a/tests/unit/payments/reconciliationService.test.ts
+++ b/tests/unit/payments/reconciliationService.test.ts
@@ -1,0 +1,103 @@
+// Mock stripe before imports
+const mockStripe = {
+  issuing: {
+    cards: { retrieve: jest.fn() },
+    transactions: { list: jest.fn() },
+  },
+};
+jest.mock('@/payments/providers/stripe/stripeClient', () => ({ getStripeClient: () => mockStripe }));
+
+// Mock prisma before imports
+const mockPot = jest.fn();
+const mockLedgerEntries = jest.fn();
+const mockVirtualCard = jest.fn();
+jest.mock('@/db/client', () => ({
+  prisma: {
+    pot: { findUnique: (...args: any[]) => mockPot(...args) },
+    ledgerEntry: { findMany: (...args: any[]) => mockLedgerEntries(...args) },
+    virtualCard: { findUnique: (...args: any[]) => mockVirtualCard(...args) },
+  },
+}));
+
+import { reconcileIntent } from '@/payments/providers/stripe/reconciliationService';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('reconcileIntent', () => {
+  it('returns inSync:true when settledAmount matches stripe captured and card is canceled', async () => {
+    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 3500, status: 'SETTLED' });
+    mockLedgerEntries.mockResolvedValue([
+      { type: 'RESERVE', amount: 5000 },
+      { type: 'SETTLE', amount: 3500 },
+    ]);
+    mockVirtualCard.mockResolvedValue({ intentId: 'intent-1', stripeCardId: 'ic_123' });
+    mockStripe.issuing.cards.retrieve.mockResolvedValue({ status: 'canceled' });
+    mockStripe.issuing.transactions.list.mockResolvedValue({
+      data: [{ id: 'itxn_1', amount: 3500, type: 'capture' }],
+    });
+
+    const report = await reconcileIntent('intent-1');
+
+    expect(report.inSync).toBe(true);
+    expect(report.discrepancies).toHaveLength(0);
+    expect(report.stripe?.totalCaptured).toBe(3500);
+  });
+
+  it('returns inSync:false with discrepancy when settledAmount differs from stripe captured', async () => {
+    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 3500, status: 'SETTLED' });
+    mockLedgerEntries.mockResolvedValue([]);
+    mockVirtualCard.mockResolvedValue({ intentId: 'intent-2', stripeCardId: 'ic_456' });
+    mockStripe.issuing.cards.retrieve.mockResolvedValue({ status: 'canceled' });
+    mockStripe.issuing.transactions.list.mockResolvedValue({
+      data: [{ id: 'itxn_2', amount: 4000, type: 'capture' }],
+    });
+
+    const report = await reconcileIntent('intent-2');
+
+    expect(report.inSync).toBe(false);
+    expect(report.discrepancies).toContain('settledAmount 3500 != stripe captured 4000');
+  });
+
+  it('returns inSync:false with discrepancy when pot is SETTLED but card is still active', async () => {
+    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 3500, status: 'SETTLED' });
+    mockLedgerEntries.mockResolvedValue([]);
+    mockVirtualCard.mockResolvedValue({ intentId: 'intent-3', stripeCardId: 'ic_789' });
+    mockStripe.issuing.cards.retrieve.mockResolvedValue({ status: 'active' });
+    mockStripe.issuing.transactions.list.mockResolvedValue({
+      data: [{ id: 'itxn_3', amount: 3500, type: 'capture' }],
+    });
+
+    const report = await reconcileIntent('intent-3');
+
+    expect(report.inSync).toBe(false);
+    expect(report.discrepancies.some(d => d.includes('expects card canceled but got active'))).toBe(true);
+  });
+
+  it('returns stripe:null and inSync:true when no VirtualCard exists', async () => {
+    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 0, status: 'ACTIVE' });
+    mockLedgerEntries.mockResolvedValue([]);
+    mockVirtualCard.mockResolvedValue(null);
+
+    const report = await reconcileIntent('intent-4');
+
+    expect(report.stripe).toBeNull();
+    expect(report.inSync).toBe(true);
+    expect(report.discrepancies).toHaveLength(0);
+    expect(mockStripe.issuing.cards.retrieve).not.toHaveBeenCalled();
+  });
+
+  it('returns potStatus:null and inSync:true when no Pot exists', async () => {
+    mockPot.mockResolvedValue(null);
+    mockLedgerEntries.mockResolvedValue([]);
+    mockVirtualCard.mockResolvedValue(null);
+
+    const report = await reconcileIntent('intent-5');
+
+    expect(report.internal.potStatus).toBeNull();
+    expect(report.internal.reserved).toBe(0);
+    expect(report.internal.settled).toBe(0);
+    expect(report.inSync).toBe(true);
+  });
+});

--- a/tests/unit/payments/webhookHandler.test.ts
+++ b/tests/unit/payments/webhookHandler.test.ts
@@ -12,6 +12,11 @@ jest.mock('@/db/client', () => ({
   prisma: { auditEvent: { create: mockAuditCreate } },
 }));
 
+const mockReconcileIntent = jest.fn();
+jest.mock('@/payments/providers/stripe/reconciliationService', () => ({
+  reconcileIntent: (...args: any[]) => mockReconcileIntent(...args),
+}));
+
 import { handleStripeEvent } from '@/payments/providers/stripe/webhookHandler';
 
 const RAW_BODY = Buffer.from('{"test":true}');
@@ -27,6 +32,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockReconcileIntent.mockResolvedValue({ inSync: true, discrepancies: [] });
 });
 
 // ─── Signature verification ──────────────────────────────────────────────────
@@ -118,6 +124,51 @@ describe('issuing_transaction.created', () => {
         payload: { transactionId: 'itxn_1', amount: 4500 },
       },
     });
+  });
+});
+
+// ─── issuing_transaction.created — reconciliation ────────────────────────────
+
+describe('issuing_transaction.created reconciliation', () => {
+  const txnObj = { id: 'itxn_r1', amount: 4500, metadata: { intentId: 'intent-recon' } };
+
+  beforeEach(() => {
+    mockConstructEvent.mockReturnValue(makeEvent('issuing_transaction.created', txnObj));
+  });
+
+  it('calls reconcileIntent with the intentId', async () => {
+    mockReconcileIntent.mockResolvedValue({ inSync: true, discrepancies: [] });
+    await handleStripeEvent(RAW_BODY, SIGNATURE);
+    // Allow fire-and-forget to settle
+    await new Promise(resolve => setImmediate(resolve));
+    expect(mockReconcileIntent).toHaveBeenCalledWith('intent-recon');
+  });
+
+  it('logs RECONCILIATION_DISCREPANCY when reconcileIntent returns inSync:false', async () => {
+    const discrepancies = ['settledAmount 3500 != stripe captured 4000'];
+    const report = { inSync: false, discrepancies, intentId: 'intent-recon', internal: {}, stripe: null };
+    mockReconcileIntent.mockResolvedValue(report);
+
+    await handleStripeEvent(RAW_BODY, SIGNATURE);
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(mockAuditCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          event: 'RECONCILIATION_DISCREPANCY',
+          intentId: 'intent-recon',
+        }),
+      }),
+    );
+  });
+
+  it('does not throw when reconcileIntent rejects', async () => {
+    mockReconcileIntent.mockRejectedValue(new Error('stripe down'));
+
+    const result = await handleStripeEvent(RAW_BODY, SIGNATURE);
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(result).toEqual({ received: true });
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `reconcileIntent(intentId)` in `src/payments/providers/stripe/reconciliationService.ts` that compares internal `Pot`/`LedgerEntry` records against Stripe `issuing_transaction` totals and card status
- Hooks into the `issuing_transaction.created` webhook handler (fire-and-forget) — discrepancies are written as `RECONCILIATION_DISCREPANCY` audit events, observable via `GET /v1/debug/audit/:intentId`
- Adds `ReconciliationReport` type to `src/contracts/reconciliation.ts`

Closes #47

## Test plan

- [x] Unit tests for `reconciliationService` (5 cases: in-sync, amount mismatch, status mismatch, no card, no pot)
- [x] Unit tests for webhook handler reconciliation trigger (3 cases: triggers reconcile, logs discrepancy, error resilience)
- [x] Integration test in `tests/integration/stripe/reconciliation.test.ts` (skipped without real Stripe key)
- [x] `npm test -- --testPathPattern="reconciliationService|webhookHandler"` — 20/20 passing