### PR TITLE
feat(telegram): add /menu command with inline keyboard navigation

### DIFF
--- a/docs/telegram-setup.md
+++ b/docs/telegram-setup.md
@@ -130,7 +130,29 @@ curl -X POST http://localhost:3000/v1/users/<userId>/link-telegram \
 
 Errors: `400` (missing or invalid body), `404` (userId not found — re-run `npm run seed`). No auth required.
 
-### Step 6A — Test it
+### Step 6A — Explore the menu
+
+Once your account is linked, send `/menu` to the bot. You'll see an inline keyboard:
+
+```
+[💰 Balance]       [📋 History]
+[🚫 Cancel Intent] [🔗 Agent Status]
+[⚙️ Preferences]
+```
+
+| Button | What it shows |
+|--------|--------------|
+| 💰 Balance | Main balance, reserved amount, available balance |
+| 📋 History | Last 5 completed purchases |
+| 🚫 Cancel Intent | Active intents you can cancel (tap one to confirm) |
+| 🔗 Agent Status | Which agent is linked to your account |
+| ⚙️ Preferences | Coming soon (card TTL / cancel policy) |
+
+Every screen has a ⬅️ Back button that returns to the main menu.
+
+> If you haven't signed up yet, `/menu` replies with a prompt to run `/start <code>` first.
+
+### Step 7A — Test an approval
 
 ```bash
 # Create an intent (use the userId from Step 5A)
@@ -212,3 +234,5 @@ Once a user is signed up, create an intent and run the stub worker (same as Path
 | `401` on webhook endpoint | Wrong `TELEGRAM_WEBHOOK_SECRET` | Ensure `.env` value matches the `secret_token` in Step 4 |
 | ngrok auth error | No authtoken configured | Run `ngrok config add-authtoken <token>` |
 | `POST /v1/users/:userId/link-telegram` returns 404 | userId is wrong or DB was reset | Re-run `npm run seed` and use the printed userId |
+| `/menu` gives no response | Webhook not registered or server not running | Re-run Step 4; ensure `npm run dev` is running |
+| `/menu` says "sign up first" | No account linked to your chat ID | Run `npm run seed` (with `TELEGRAM_TEST_CHAT_ID` set) or complete the `/start <code>` flow |

--- a/src/telegram/callbackHandler.ts
+++ b/src/telegram/callbackHandler.ts
@@ -8,6 +8,7 @@ import { markCardIssued, startCheckout } from '@/orchestrator/intentService';
 import { enqueueCheckout } from '@/queue/producers';
 import { getTelegramBot } from './telegramClient';
 import { getSignupSession, setSignupSession, clearSignupSession } from './sessionStore';
+import { handleMenuCallback } from './menuHandler';
 
 export async function handleTelegramCallback(update: Update): Promise<void> {
   const cb = update.callback_query;
@@ -29,6 +30,12 @@ export async function handleTelegramCallback(update: Update): Promise<void> {
   if (colonIdx === -1) return;
   const action = data.slice(0, colonIdx);
   const payload = data.slice(colonIdx + 1);
+
+  // ── Menu callbacks ────────────────────────────────────────────────────────────
+  if (action.startsWith('menu_')) {
+    await handleMenuCallback(bot, chatId!, messageId!, action, payload, fromId);
+    return;
+  }
 
   // ── Agent linking confirmation callbacks ─────────────────────────────────────
   if (action === 'link_confirm' || action === 'link_cancel') {

--- a/src/telegram/menuHandler.ts
+++ b/src/telegram/menuHandler.ts
@@ -1,0 +1,281 @@
+import { InlineKeyboard } from 'grammy';
+import { prisma } from '@/db/client';
+import { getTelegramBot } from './telegramClient';
+import { expireIntent } from '@/orchestrator/intentService';
+import { IntentStatus } from '@/contracts';
+
+const ACTIVE_INTENT_STATUSES: IntentStatus[] = [
+  IntentStatus.RECEIVED,
+  IntentStatus.SEARCHING,
+  IntentStatus.QUOTED,
+  IntentStatus.AWAITING_APPROVAL,
+  IntentStatus.APPROVED,
+  IntentStatus.CARD_ISSUED,
+  IntentStatus.CHECKOUT_RUNNING,
+];
+
+function formatAmount(amountInCents: number): string {
+  return `£${(amountInCents / 100).toFixed(2)}`;
+}
+
+function buildMainMenuKeyboard(): InlineKeyboard {
+  return new InlineKeyboard()
+    .text('💰 Balance', 'menu_balance:_')
+    .text('📋 History', 'menu_history:_')
+    .row()
+    .text('🚫 Cancel Intent', 'menu_cancel_list:_')
+    .text('🔗 Agent Status', 'menu_agent:_')
+    .row()
+    .text('⚙️ Preferences', 'menu_preferences:_');
+}
+
+async function getUserByChatId(chatId: number | string) {
+  return prisma.user.findFirst({ where: { telegramChatId: String(chatId) } });
+}
+
+async function editMenu(
+  bot: ReturnType<typeof getTelegramBot>,
+  chatId: number | string,
+  messageId: number,
+  text: string,
+  keyboard?: InlineKeyboard,
+): Promise<void> {
+  await bot.api
+    .editMessageText(chatId, messageId, text, {
+      parse_mode: 'HTML',
+      reply_markup: keyboard,
+    })
+    .catch(() => {});
+}
+
+async function showBalance(
+  bot: ReturnType<typeof getTelegramBot>,
+  chatId: number | string,
+  messageId: number,
+  user: { id: string; mainBalance: number },
+): Promise<void> {
+  const activePots = await prisma.pot.findMany({
+    where: { userId: user.id, status: 'ACTIVE' },
+    select: { reservedAmount: true },
+  });
+
+  const reserved = activePots.reduce((sum, p) => sum + p.reservedAmount, 0);
+  const available = user.mainBalance - reserved;
+
+  const text =
+    `💰 <b>Your Balance</b>\n\n` +
+    `Main balance: ${formatAmount(user.mainBalance)}\n` +
+    `Reserved:     ${formatAmount(reserved)}\n` +
+    `Available:    ${formatAmount(available)}`;
+
+  const keyboard = new InlineKeyboard().text('⬅️ Back', 'menu_main:_');
+  await editMenu(bot, chatId, messageId, text, keyboard);
+}
+
+async function showHistory(
+  bot: ReturnType<typeof getTelegramBot>,
+  chatId: number | string,
+  messageId: number,
+  user: { id: string },
+): Promise<void> {
+  const intents = await prisma.purchaseIntent.findMany({
+    where: { userId: user.id, status: IntentStatus.DONE },
+    orderBy: { createdAt: 'desc' },
+    take: 5,
+    include: { pot: true },
+  });
+
+  let text = '📋 <b>Recent Purchases</b>\n\n';
+  if (intents.length === 0) {
+    text += 'No purchases yet.';
+  } else {
+    text += intents
+      .map((i) => {
+        const amount = i.pot ? formatAmount(i.pot.settledAmount) : formatAmount(i.maxBudget);
+        return `• ${i.subject ?? i.query} — ${amount}`;
+      })
+      .join('\n');
+  }
+
+  const keyboard = new InlineKeyboard().text('⬅️ Back', 'menu_main:_');
+  await editMenu(bot, chatId, messageId, text, keyboard);
+}
+
+async function showCancelList(
+  bot: ReturnType<typeof getTelegramBot>,
+  chatId: number | string,
+  messageId: number,
+  user: { id: string },
+): Promise<void> {
+  const intents = await prisma.purchaseIntent.findMany({
+    where: { userId: user.id, status: { in: ACTIVE_INTENT_STATUSES } },
+    orderBy: { createdAt: 'desc' },
+  });
+
+  const keyboard = new InlineKeyboard();
+  let text: string;
+
+  if (intents.length === 0) {
+    text = '🚫 <b>Cancel Intent</b>\n\nNo active intents.';
+  } else {
+    text = '🚫 <b>Cancel Intent</b>\n\nSelect an intent to cancel:';
+    for (const intent of intents) {
+      const label = `${intent.status}: ${intent.subject ?? intent.query}  ${formatAmount(intent.maxBudget)}`;
+      keyboard.row().text(label, `menu_cancel_confirm:${intent.id}`);
+    }
+  }
+
+  keyboard.row().text('⬅️ Back', 'menu_main:_');
+  await editMenu(bot, chatId, messageId, text, keyboard);
+}
+
+async function showCancelConfirm(
+  bot: ReturnType<typeof getTelegramBot>,
+  chatId: number | string,
+  messageId: number,
+  intentId: string,
+): Promise<void> {
+  const intent = await prisma.purchaseIntent.findUnique({ where: { id: intentId } });
+
+  if (!intent) {
+    const keyboard = new InlineKeyboard().text('⬅️ Back', 'menu_cancel_list:_');
+    await editMenu(bot, chatId, messageId, '⚠️ Intent not found.', keyboard);
+    return;
+  }
+
+  const label = intent.subject ?? intent.query;
+  const text =
+    `🚫 Cancel "<b>${label}</b>" (${intent.status})?\n\n` +
+    `Budget: ${formatAmount(intent.maxBudget)} will be returned to your balance.`;
+
+  const keyboard = new InlineKeyboard()
+    .text('✅ Yes, cancel', `menu_cancel_do:${intentId}`)
+    .text('⬅️ Back to list', 'menu_cancel_list:_');
+
+  await editMenu(bot, chatId, messageId, text, keyboard);
+}
+
+async function doCancelIntent(
+  bot: ReturnType<typeof getTelegramBot>,
+  chatId: number | string,
+  messageId: number,
+  intentId: string,
+): Promise<void> {
+  try {
+    await expireIntent(intentId);
+    const keyboard = new InlineKeyboard().text('⬅️ Back', 'menu_main:_');
+    await editMenu(bot, chatId, messageId, '✅ Intent cancelled. Your budget has been returned.', keyboard);
+  } catch {
+    const keyboard = new InlineKeyboard().text('⬅️ Back', 'menu_main:_');
+    await editMenu(bot, chatId, messageId, '⚠️ Something went wrong. Please try again.', keyboard);
+  }
+}
+
+async function showAgentStatus(
+  bot: ReturnType<typeof getTelegramBot>,
+  chatId: number | string,
+  messageId: number,
+  user: { agentId: string | null },
+): Promise<void> {
+  let text: string;
+  if (user.agentId) {
+    text = `🔗 <b>Agent Status</b>\n\nLinked: <code>${user.agentId}</code>`;
+  } else {
+    text = '🔗 <b>Agent Status</b>\n\nNo agent linked. Use /start &lt;code&gt; to link.';
+  }
+
+  const keyboard = new InlineKeyboard().text('⬅️ Back', 'menu_main:_');
+  await editMenu(bot, chatId, messageId, text, keyboard);
+}
+
+async function showPreferences(
+  bot: ReturnType<typeof getTelegramBot>,
+  chatId: number | string,
+  messageId: number,
+): Promise<void> {
+  const text =
+    '⚙️ <b>Preferences</b> — coming soon.\n\nCard TTL and cancel policy settings will be available here.';
+  const keyboard = new InlineKeyboard().text('⬅️ Back', 'menu_main:_');
+  await editMenu(bot, chatId, messageId, text, keyboard);
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+export async function sendMainMenu(chatId: number | string): Promise<void> {
+  const bot = getTelegramBot();
+  const user = await getUserByChatId(chatId);
+
+  if (!user) {
+    await bot.api.sendMessage(
+      chatId,
+      '⚠️ You need to sign up first. Send /start &lt;code&gt; to get started.',
+      { parse_mode: 'HTML' },
+    );
+    return;
+  }
+
+  const keyboard = buildMainMenuKeyboard();
+  await bot.api.sendMessage(chatId, '📱 <b>Main Menu</b>', {
+    parse_mode: 'HTML',
+    reply_markup: keyboard,
+  });
+}
+
+export async function handleMenuCallback(
+  bot: ReturnType<typeof getTelegramBot>,
+  chatId: number | string,
+  messageId: number,
+  action: string,
+  payload: string,
+  fromTelegramId: number,
+): Promise<void> {
+  // Actions that don't need a user record
+  if (action === 'menu_main') {
+    const keyboard = buildMainMenuKeyboard();
+    await editMenu(bot, chatId, messageId, '📱 <b>Main Menu</b>', keyboard);
+    return;
+  }
+
+  if (action === 'menu_preferences') {
+    await showPreferences(bot, chatId, messageId);
+    return;
+  }
+
+  if (action === 'menu_cancel_confirm') {
+    await showCancelConfirm(bot, chatId, messageId, payload);
+    return;
+  }
+
+  if (action === 'menu_cancel_do') {
+    await doCancelIntent(bot, chatId, messageId, payload);
+    return;
+  }
+
+  // Actions that need a user record — look up by fromTelegramId (same as chatId for private chats)
+  const user = await getUserByChatId(chatId);
+
+  if (!user) {
+    await editMenu(
+      bot,
+      chatId,
+      messageId,
+      '⚠️ You need to sign up first. Send /start &lt;code&gt; to get started.',
+    );
+    return;
+  }
+
+  try {
+    if (action === 'menu_balance') {
+      await showBalance(bot, chatId, messageId, user);
+    } else if (action === 'menu_history') {
+      await showHistory(bot, chatId, messageId, user);
+    } else if (action === 'menu_cancel_list') {
+      await showCancelList(bot, chatId, messageId, user);
+    } else if (action === 'menu_agent') {
+      await showAgentStatus(bot, chatId, messageId, user);
+    }
+    // Unknown menu_* actions: silently ignore (no crash)
+  } catch {
+    await editMenu(bot, chatId, messageId, '⚠️ Something went wrong. Please try again.');
+  }
+}

--- a/src/telegram/signupHandler.ts
+++ b/src/telegram/signupHandler.ts
@@ -5,6 +5,7 @@ import bcrypt from 'bcryptjs';
 import { prisma } from '@/db/client';
 import { getTelegramBot } from './telegramClient';
 import { getSignupSession, setSignupSession, clearSignupSession } from './sessionStore';
+import { sendMainMenu } from './menuHandler';
 
 export async function handleTelegramMessage(update: Update): Promise<void> {
   const message = update.message;
@@ -13,6 +14,12 @@ export async function handleTelegramMessage(update: Update): Promise<void> {
   const chatId = message.chat.id;
   const text = (message.text ?? '').trim();
   const bot = getTelegramBot();
+
+  // Handle /menu command
+  if (text === '/menu') {
+    await sendMainMenu(chatId);
+    return;
+  }
 
   // Handle /start <code> command
   if (text.startsWith('/start')) {

--- a/tests/integration/telegram/menuHandler.live.test.ts
+++ b/tests/integration/telegram/menuHandler.live.test.ts
@@ -1,0 +1,458 @@
+/**
+ * Interactive live Telegram test — /menu command.
+ *
+ * Sends the real inline keyboard to TELEGRAM_TEST_CHAT_ID, then waits for you
+ * to actually tap each button before advancing. Each step sends an instruction
+ * message telling you exactly which button to press next.
+ *
+ * How it works:
+ *   1. The test deletes the webhook so Telegram delivers updates to getUpdates.
+ *   2. Each step sends the menu (or an instruction) directly to your chat.
+ *   3. The test polls getUpdates, waiting for your tap.
+ *   4. When a tap arrives it is forwarded to the local Fastify app, which
+ *      calls the real Telegram Bot API to edit the message in-place.
+ *   5. The next instruction appears and the loop continues.
+ *
+ * Run:
+ *   npx jest --config jest.integration.live.js \
+ *            --testPathPattern=menuHandler.live \
+ *            --forceExit --testTimeout=120000
+ *
+ * Requires:
+ *   - TELEGRAM_BOT_TOKEN and TELEGRAM_TEST_CHAT_ID in .env
+ *   - docker compose up -d  (Postgres + Redis)
+ *
+ * Note: the webhook is deleted at the start and restored at the end
+ * (to the URL stored in getWebhookInfo before the test runs).
+ */
+
+import crypto from 'crypto';
+import bcrypt from 'bcryptjs';
+import { prisma } from '@/db/client';
+import { getRedisClient } from '@/config/redis';
+
+// BullMQ producers mocked — no worker needed
+jest.mock('@/queue/producers', () => ({
+  enqueueSearch: jest.fn().mockResolvedValue(undefined),
+  enqueueCheckout: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { buildApp } from '@/app';
+import type { FastifyInstance } from 'fastify';
+
+// ── Environment ───────────────────────────────────────────────────────────────
+
+const TELEGRAM_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+const TEST_CHAT_ID = process.env.TELEGRAM_TEST_CHAT_ID
+  ? parseInt(process.env.TELEGRAM_TEST_CHAT_ID, 10)
+  : null;
+const TELEGRAM_SECRET = process.env.TELEGRAM_WEBHOOK_SECRET ?? 'ilovedatadogok';
+const BASE = `https://api.telegram.org/bot${TELEGRAM_TOKEN}`;
+const isMockEnv = process.env.TELEGRAM_MOCK === 'true';
+
+const canRun = !!TELEGRAM_TOKEN && !!TEST_CHAT_ID && !isMockEnv;
+const testSuite = canRun ? describe : describe.skip;
+
+// ── Low-level Telegram API helpers ────────────────────────────────────────────
+
+async function tgGet(method: string, params: Record<string, unknown> = {}) {
+  const qs = new URLSearchParams(
+    Object.entries(params).map(([k, v]) => [k, String(v)]),
+  ).toString();
+  const url = qs ? `${BASE}/${method}?${qs}` : `${BASE}/${method}`;
+  const res = await fetch(url);
+  return res.json() as Promise<any>;
+}
+
+async function tgPost(method: string, payload: Record<string, unknown>) {
+  const res = await fetch(`${BASE}/${method}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  return res.json() as Promise<any>;
+}
+
+// ── Main menu keyboard (matches buildMainMenuKeyboard in menuHandler.ts) ──────
+
+const MAIN_MENU_KEYBOARD = {
+  inline_keyboard: [
+    [
+      { text: '💰 Balance',      callback_data: 'menu_balance:_' },
+      { text: '📋 History',      callback_data: 'menu_history:_' },
+    ],
+    [
+      { text: '🚫 Cancel Intent', callback_data: 'menu_cancel_list:_' },
+      { text: '🔗 Agent Status',  callback_data: 'menu_agent:_' },
+    ],
+    [
+      { text: '⚙️ Preferences',  callback_data: 'menu_preferences:_' },
+    ],
+  ],
+};
+
+// ── App + poll state ──────────────────────────────────────────────────────────
+
+let app: FastifyInstance;
+let menuMessageId: number;   // message_id of the live menu message in the chat
+let updateOffset = 0;        // rolling getUpdates offset to avoid re-processing
+
+function pause(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// ── Webhook management ────────────────────────────────────────────────────────
+
+let originalWebhookUrl = '';
+
+async function disableWebhook() {
+  const info = await tgGet('getWebhookInfo');
+  originalWebhookUrl = info.result?.url ?? '';
+  await tgPost('deleteWebhook', { drop_pending_updates: false });
+}
+
+async function restoreWebhook() {
+  if (originalWebhookUrl) {
+    await tgPost('setWebhook', { url: originalWebhookUrl });
+  }
+}
+
+// ── User input: wait for a real button tap ────────────────────────────────────
+
+async function waitForCallback(
+  allowed: string[],
+  timeoutMs = 90_000,
+): Promise<{ action: string; payload: string; messageId: number; callbackId: string }> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const remaining = Math.floor((deadline - Date.now()) / 1000);
+    const pollSecs = Math.min(remaining, 25);
+    if (pollSecs <= 0) break;
+
+    const result = await tgGet('getUpdates', {
+      offset: updateOffset,
+      timeout: pollSecs,
+      allowed_updates: 'callback_query',
+    });
+
+    if (!result.ok) throw new Error(`getUpdates error: ${result.description}`);
+
+    for (const update of result.result ?? []) {
+      updateOffset = update.update_id + 1;
+      const cb = update.callback_query;
+      if (!cb || cb.from.id !== TEST_CHAT_ID) continue;
+
+      const colonIdx = (cb.data ?? '').indexOf(':');
+      const action = cb.data.slice(0, colonIdx);
+      const payload = cb.data.slice(colonIdx + 1);
+
+      if (allowed.includes(action)) {
+        return {
+          action,
+          payload,
+          messageId: cb.message?.message_id ?? menuMessageId,
+          callbackId: cb.id,
+        };
+      }
+
+      // Unexpected button — acknowledge it and keep waiting
+      await tgPost('answerCallbackQuery', {
+        callback_query_id: cb.id,
+        text: `Expected one of: ${allowed.join(', ')}`,
+        show_alert: false,
+      });
+    }
+  }
+
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for: ${allowed.join(', ')}`);
+}
+
+// ── Forward a received tap to the local Fastify app ───────────────────────────
+
+async function forwardCallback(
+  cb: { action: string; payload: string; messageId: number; callbackId: string },
+) {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/v1/webhooks/telegram',
+    headers: { 'x-telegram-bot-api-secret-token': TELEGRAM_SECRET },
+    payload: {
+      update_id: Math.floor(Math.random() * 1e9),
+      callback_query: {
+        id: cb.callbackId,
+        data: `${cb.action}:${cb.payload}`,
+        from: { id: TEST_CHAT_ID },
+        message: { message_id: cb.messageId, chat: { id: TEST_CHAT_ID } },
+      },
+    },
+  });
+  expect(res.statusCode).toBe(200);
+  await pause(400); // allow editMessageText to reach Telegram
+}
+
+// ── Helpers to send plain instruction messages ────────────────────────────────
+
+async function instruct(text: string) {
+  await tgPost('sendMessage', {
+    chat_id: TEST_CHAT_ID,
+    text,
+    parse_mode: 'HTML',
+  });
+}
+
+// ── DB setup ──────────────────────────────────────────────────────────────────
+
+let userId: string;
+let cancelIntentId: string;
+
+async function buildFixtures() {
+  const rawKey = crypto.randomBytes(32).toString('hex');
+  const apiKeyHash = await bcrypt.hash(rawKey, 10);
+  const user = await prisma.user.create({
+    data: {
+      email: `live-menu-${Date.now()}@example.com`,
+      telegramChatId: String(TEST_CHAT_ID),
+      agentId: 'live-agent-001',
+      mainBalance: 35000,    // £350.00 total
+      maxBudgetPerIntent: 50000,
+      apiKeyHash,
+      apiKeyPrefix: rawKey.slice(0, 16),
+    },
+  });
+  userId = user.id;
+
+  // History: one DONE intent
+  const doneIntent = await prisma.purchaseIntent.create({
+    data: {
+      userId,
+      query: 'Sony headphones',
+      subject: 'Sony headphones',
+      maxBudget: 4500,
+      currency: 'gbp',
+      status: 'DONE',
+      metadata: {},
+      idempotencyKey: `live-done-${Date.now()}`,
+    },
+  });
+  await prisma.pot.create({
+    data: { userId, intentId: doneIntent.id, reservedAmount: 4500, settledAmount: 4000, status: 'SETTLED' },
+  });
+
+  // Cancel list: one active intent with a pot (balance already decremented)
+  const activeIntent = await prisma.purchaseIntent.create({
+    data: {
+      userId,
+      query: 'Coffee maker',
+      subject: 'Coffee maker',
+      maxBudget: 8900,
+      currency: 'gbp',
+      status: 'SEARCHING',
+      metadata: {},
+      idempotencyKey: `live-active-${Date.now()}`,
+    },
+  });
+  cancelIntentId = activeIntent.id;
+
+  // Balance: reserve £50 from the £350
+  await prisma.user.update({ where: { id: userId }, data: { mainBalance: 30000 } });
+  await prisma.pot.create({
+    data: { userId, intentId: activeIntent.id, reservedAmount: 5000, status: 'ACTIVE' },
+  });
+}
+
+async function cleanDb() {
+  await prisma.auditEvent.deleteMany();
+  await prisma.ledgerEntry.deleteMany();
+  await prisma.pot.deleteMany();
+  await prisma.virtualCard.deleteMany();
+  await prisma.approvalDecision.deleteMany();
+  await prisma.purchaseIntent.deleteMany();
+  await prisma.idempotencyRecord.deleteMany();
+  await prisma.pairingCode.deleteMany();
+  await prisma.user.deleteMany();
+  const redis = getRedisClient();
+  const keys = await redis.keys('telegram_signup:*');
+  if (keys.length) await redis.del(...keys);
+}
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
+
+jest.setTimeout(120_000);
+
+beforeAll(async () => {
+  if (!canRun) return;
+  app = buildApp();
+  await app.ready();
+  await cleanDb();
+  await buildFixtures();
+  await disableWebhook();
+  // Drain any stale pending updates before we start
+  const drain = await tgGet('getUpdates', { timeout: 1, offset: 0 });
+  if (drain.ok && drain.result.length > 0) {
+    updateOffset = drain.result[drain.result.length - 1].update_id + 1;
+  }
+});
+
+afterAll(async () => {
+  if (!canRun) return;
+  await cleanDb();
+  await restoreWebhook();
+  await app.close();
+  await prisma.$disconnect();
+  getRedisClient().disconnect();
+});
+
+// ── Interactive steps ─────────────────────────────────────────────────────────
+
+testSuite('Telegram /menu — interactive live walkthrough', () => {
+  // ── Step 1: Send the main menu ──────────────────────────────────────────────
+
+  it('Step 1 — sends the main menu keyboard', async () => {
+    const result = await tgPost('sendMessage', {
+      chat_id: TEST_CHAT_ID,
+      text: '📱 <b>Main Menu</b>',
+      parse_mode: 'HTML',
+      reply_markup: MAIN_MENU_KEYBOARD,
+    });
+    expect(result.ok).toBe(true);
+    menuMessageId = result.result.message_id;
+    console.log(`\nMenu sent (message_id: ${menuMessageId})`);
+  });
+
+  // ── Step 2: Balance screen ──────────────────────────────────────────────────
+
+  it('Step 2 — Balance screen (tap 💰 Balance)', async () => {
+    await instruct('👆 Tap <b>[💰 Balance]</b> in the menu above.');
+
+    const cb = await waitForCallback(['menu_balance']);
+    console.log(`\nReceived tap: ${cb.action}`);
+
+    await forwardCallback(cb);
+    console.log('✓ Balance screen shown (main menu message edited in-place)');
+  });
+
+  // ── Step 3: Back to main ────────────────────────────────────────────────────
+
+  it('Step 3 — Back to main menu (tap ⬅️ Back)', async () => {
+    await instruct('👆 Tap <b>[⬅️ Back]</b> to return to the main menu.');
+
+    const cb = await waitForCallback(['menu_main']);
+    console.log(`\nReceived tap: ${cb.action}`);
+
+    await forwardCallback(cb);
+    console.log('✓ Main menu restored');
+  });
+
+  // ── Step 4: History screen ──────────────────────────────────────────────────
+
+  it('Step 4 — History screen (tap 📋 History)', async () => {
+    await instruct('👆 Tap <b>[📋 History]</b> in the main menu.');
+
+    const cb = await waitForCallback(['menu_history']);
+    console.log(`\nReceived tap: ${cb.action}`);
+
+    await forwardCallback(cb);
+    console.log('✓ History screen shown — expect: • Sony headphones — £40.00');
+  });
+
+  // ── Step 5: Back → Cancel list ──────────────────────────────────────────────
+
+  it('Step 5 — Cancel Intent list (tap ⬅️ Back, then 🚫 Cancel Intent)', async () => {
+    await instruct('👆 Tap <b>[⬅️ Back]</b>, then tap <b>[🚫 Cancel Intent]</b>.');
+
+    const back = await waitForCallback(['menu_main']);
+    await forwardCallback(back);
+
+    await instruct('👆 Now tap <b>[🚫 Cancel Intent]</b>.');
+
+    const list = await waitForCallback(['menu_cancel_list']);
+    console.log(`\nReceived tap: ${list.action}`);
+
+    await forwardCallback(list);
+    console.log('✓ Cancel list shown — expect one button: [SEARCHING: Coffee maker  £89.00]');
+  });
+
+  // ── Step 6: Cancel confirm ──────────────────────────────────────────────────
+
+  it('Step 6 — Cancel confirm screen (tap the Coffee maker intent button)', async () => {
+    await instruct('👆 Tap <b>[SEARCHING: Coffee maker £89.00]</b> to see the confirm screen.');
+
+    const cb = await waitForCallback(['menu_cancel_confirm']);
+    console.log(`\nReceived tap: ${cb.action}:${cb.payload}`);
+    cancelIntentId = cb.payload; // capture the real intentId
+
+    await forwardCallback(cb);
+    console.log('✓ Confirm screen shown — expect [✅ Yes, cancel] and [⬅️ Back to list]');
+  });
+
+  // ── Step 7: Confirm cancellation ────────────────────────────────────────────
+
+  it('Step 7 — Confirm cancel (tap ✅ Yes, cancel)', async () => {
+    await instruct('👆 Tap <b>[✅ Yes, cancel]</b> to confirm cancellation.');
+
+    const cb = await waitForCallback(['menu_cancel_do']);
+    console.log(`\nReceived tap: ${cb.action}:${cb.payload}`);
+
+    await forwardCallback(cb);
+
+    // Verify the intent is now EXPIRED in the DB
+    await pause(300);
+    const intent = await prisma.purchaseIntent.findUnique({ where: { id: cb.payload } });
+    expect(intent!.status).toBe('EXPIRED');
+    console.log(`✓ Intent ${cb.payload} → EXPIRED in DB`);
+    console.log('✓ Confirmation message shown');
+  });
+
+  // ── Step 8: Agent status ────────────────────────────────────────────────────
+
+  it('Step 8 — Agent Status screen (tap ⬅️ Back, then 🔗 Agent Status)', async () => {
+    await instruct('👆 Tap <b>[⬅️ Back]</b>, then tap <b>[🔗 Agent Status]</b>.');
+
+    const back = await waitForCallback(['menu_main']);
+    await forwardCallback(back);
+
+    await instruct('👆 Now tap <b>[🔗 Agent Status]</b>.');
+
+    const cb = await waitForCallback(['menu_agent']);
+    console.log(`\nReceived tap: ${cb.action}`);
+
+    await forwardCallback(cb);
+    console.log('✓ Agent status shown — expect: Linked: live-agent-001');
+  });
+
+  // ── Step 9: Preferences stub ────────────────────────────────────────────────
+
+  it('Step 9 — Preferences screen (tap ⬅️ Back, then ⚙️ Preferences)', async () => {
+    await instruct('👆 Tap <b>[⬅️ Back]</b>, then tap <b>[⚙️ Preferences]</b>.');
+
+    const back = await waitForCallback(['menu_main']);
+    await forwardCallback(back);
+
+    await instruct('👆 Now tap <b>[⚙️ Preferences]</b>.');
+
+    const cb = await waitForCallback(['menu_preferences']);
+    console.log(`\nReceived tap: ${cb.action}`);
+
+    await forwardCallback(cb);
+    console.log('✓ Preferences stub shown — expect: coming soon');
+  });
+
+  // ── Step 10: Return to main ──────────────────────────────────────────────────
+
+  it('Step 10 — Back to main menu (tap ⬅️ Back)', async () => {
+    await instruct('👆 Tap <b>[⬅️ Back]</b> to return to the main menu — this is the last step.');
+
+    const cb = await waitForCallback(['menu_main']);
+    console.log(`\nReceived tap: ${cb.action}`);
+
+    await forwardCallback(cb);
+
+    await tgPost('sendMessage', {
+      chat_id: TEST_CHAT_ID,
+      text: '✅ <b>All menu screens verified!</b> Interactive walkthrough complete.',
+      parse_mode: 'HTML',
+    });
+    console.log('\n✓ All 10 steps complete — interactive walkthrough finished.');
+  });
+});

--- a/tests/integration/telegram/menuHandler.test.ts
+++ b/tests/integration/telegram/menuHandler.test.ts
@@ -1,0 +1,426 @@
+/**
+ * Integration tests: Telegram /menu command and menu callbacks
+ *
+ * Uses real PostgreSQL and the full Fastify app. Telegram outbound API calls
+ * and BullMQ producers are mocked so no external services are required beyond
+ * a running Postgres + Redis instance.
+ *
+ * Run: npm run test:integration -- --testPathPattern=telegram/menuHandler
+ */
+
+import { prisma } from '@/db/client';
+import { getRedisClient } from '@/config/redis';
+
+// Mock Telegram outbound calls — we never send real Telegram messages in tests
+const mockSendMessage = jest.fn().mockResolvedValue({ message_id: 1 });
+const mockAnswerCallbackQuery = jest.fn().mockResolvedValue(undefined);
+const mockEditMessageText = jest.fn().mockResolvedValue(undefined);
+jest.mock('@/telegram/telegramClient', () => ({
+  getTelegramBot: () => ({
+    api: {
+      sendMessage: mockSendMessage,
+      answerCallbackQuery: mockAnswerCallbackQuery,
+      editMessageText: mockEditMessageText,
+    },
+  }),
+}));
+
+// Mock BullMQ producers — no real worker needed
+jest.mock('@/queue/producers', () => ({
+  enqueueSearch: jest.fn().mockResolvedValue(undefined),
+  enqueueCheckout: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { buildApp } from '@/app';
+import type { FastifyInstance } from 'fastify';
+
+const TELEGRAM_SECRET = process.env.TELEGRAM_WEBHOOK_SECRET ?? 'ilovedatadogok';
+const hasStripeKey = process.env.STRIPE_SECRET_KEY?.startsWith('sk_test_');
+
+const TEST_CHAT_ID = 55551234;
+const TEST_MSG_ID = 42;
+
+let app: FastifyInstance;
+
+// ── DB helpers ────────────────────────────────────────────────────────────────
+
+async function createTestUser(overrides: Partial<{
+  agentId: string | null;
+  mainBalance: number;
+}> = {}) {
+  return prisma.user.create({
+    data: {
+      email: `menu-test-${Date.now()}@example.com`,
+      telegramChatId: String(TEST_CHAT_ID),
+      agentId: overrides.agentId !== undefined ? overrides.agentId : 'agent-menu-test',
+      mainBalance: overrides.mainBalance ?? 12500,
+      maxBudgetPerIntent: 50000,
+      apiKeyHash: 'irrelevant',
+      apiKeyPrefix: 'irrelevant',
+    },
+  });
+}
+
+async function createIntent(userId: string, opts: { status?: string; budget?: number; subject?: string } = {}) {
+  return prisma.purchaseIntent.create({
+    data: {
+      userId,
+      query: opts.subject ?? 'test item',
+      subject: opts.subject ?? 'test item',
+      maxBudget: opts.budget ?? 5000,
+      currency: 'gbp',
+      status: (opts.status ?? 'SEARCHING') as any,
+      metadata: {},
+      idempotencyKey: `idem-${Date.now()}-${Math.random()}`,
+    },
+  });
+}
+
+async function createPot(userId: string, intentId: string, reservedAmount: number) {
+  return prisma.pot.create({
+    data: { userId, intentId, reservedAmount, status: 'ACTIVE' },
+  });
+}
+
+// ── Webhook injection helpers ─────────────────────────────────────────────────
+
+async function sendMenuCommand() {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/v1/webhooks/telegram',
+    headers: { 'x-telegram-bot-api-secret-token': TELEGRAM_SECRET },
+    payload: {
+      update_id: Math.floor(Math.random() * 1e9),
+      message: { message_id: TEST_MSG_ID, chat: { id: TEST_CHAT_ID }, text: '/menu' },
+    },
+  });
+  expect(res.statusCode).toBe(200);
+  // Allow fire-and-forget handler to complete
+  await new Promise((r) => setTimeout(r, 100));
+}
+
+async function sendMenuCallback(action: string, payload: string) {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/v1/webhooks/telegram',
+    headers: { 'x-telegram-bot-api-secret-token': TELEGRAM_SECRET },
+    payload: {
+      update_id: Math.floor(Math.random() * 1e9),
+      callback_query: {
+        id: `cb-${Date.now()}`,
+        data: `${action}:${payload}`,
+        from: { id: TEST_CHAT_ID },
+        message: { message_id: TEST_MSG_ID, chat: { id: TEST_CHAT_ID } },
+      },
+    },
+  });
+  expect(res.statusCode).toBe(200);
+  await new Promise((r) => setTimeout(r, 100));
+}
+
+// ── Test suite ────────────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  app = buildApp();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app.close();
+  await prisma.$disconnect();
+  getRedisClient().disconnect();
+});
+
+beforeEach(async () => {
+  await prisma.auditEvent.deleteMany();
+  await prisma.ledgerEntry.deleteMany();
+  await prisma.pot.deleteMany();
+  await prisma.virtualCard.deleteMany();
+  await prisma.approvalDecision.deleteMany();
+  await prisma.purchaseIntent.deleteMany();
+  await prisma.idempotencyRecord.deleteMany();
+  await prisma.pairingCode.deleteMany();
+  await prisma.user.deleteMany();
+  jest.clearAllMocks();
+});
+
+const testSuite = hasStripeKey ? describe : describe.skip;
+
+testSuite('Telegram /menu integration (real DB)', () => {
+  // ── /menu command ───────────────────────────────────────────────────────────
+
+  describe('/menu command', () => {
+    it('sends main menu keyboard when user is found', async () => {
+      await createTestUser();
+      await sendMenuCommand();
+
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        TEST_CHAT_ID,
+        expect.any(String),
+        expect.objectContaining({ reply_markup: expect.anything() }),
+      );
+
+      const keyboard = mockSendMessage.mock.calls[0][2].reply_markup;
+      const allButtons = keyboard.inline_keyboard.flat();
+      expect(allButtons.length).toBeGreaterThanOrEqual(5);
+
+      // All expected menu actions are present
+      const actions = allButtons.map((b: any) => b.callback_data);
+      expect(actions).toContain('menu_balance:_');
+      expect(actions).toContain('menu_history:_');
+      expect(actions).toContain('menu_cancel_list:_');
+      expect(actions).toContain('menu_agent:_');
+      expect(actions).toContain('menu_preferences:_');
+    });
+
+    it('sends signup prompt when user is not found', async () => {
+      // No user in DB — chatId is not linked
+      await sendMenuCommand();
+
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        TEST_CHAT_ID,
+        expect.stringContaining('sign up'),
+        expect.anything(),
+      );
+    });
+  });
+
+  // ── menu_balance ────────────────────────────────────────────────────────────
+
+  describe('menu_balance callback', () => {
+    it('shows main balance, reserved amount and available balance', async () => {
+      const user = await createTestUser({ mainBalance: 12500 }); // £125.00
+      const intent = await createIntent(user.id);
+      await createPot(user.id, intent.id, 2500); // £25.00 reserved
+
+      await sendMenuCallback('menu_balance', '_');
+
+      const [, , text] = mockEditMessageText.mock.calls[0];
+      expect(text).toContain('£125.00'); // main balance
+      expect(text).toContain('£25.00');  // reserved
+      expect(text).toContain('£100.00'); // available
+    });
+
+    it('shows £0.00 reserved when no active pots', async () => {
+      await createTestUser({ mainBalance: 5000 });
+
+      await sendMenuCallback('menu_balance', '_');
+
+      const [, , text] = mockEditMessageText.mock.calls[0];
+      expect(text).toContain('Reserved:     £0.00');
+    });
+  });
+
+  // ── menu_history ────────────────────────────────────────────────────────────
+
+  describe('menu_history callback', () => {
+    it('lists DONE intents with their settled amounts', async () => {
+      const user = await createTestUser();
+      const intent = await createIntent(user.id, { status: 'DONE', subject: 'headphones', budget: 4500 });
+      await createPot(user.id, intent.id, 4500);
+      // Mark pot as settled
+      await prisma.pot.update({
+        where: { intentId: intent.id },
+        data: { status: 'SETTLED', settledAmount: 4500 },
+      });
+
+      await sendMenuCallback('menu_history', '_');
+
+      const [, , text] = mockEditMessageText.mock.calls[0];
+      expect(text).toContain('headphones');
+      expect(text).toContain('£45.00');
+    });
+
+    it('shows empty state when no DONE intents', async () => {
+      await createTestUser();
+
+      await sendMenuCallback('menu_history', '_');
+
+      const [, , text] = mockEditMessageText.mock.calls[0];
+      expect(text.toLowerCase()).toContain('no purchases');
+    });
+  });
+
+  // ── menu_cancel_list ────────────────────────────────────────────────────────
+
+  describe('menu_cancel_list callback', () => {
+    it('renders one cancel button per active intent', async () => {
+      const user = await createTestUser();
+      const i1 = await createIntent(user.id, { status: 'SEARCHING', subject: 'headphones', budget: 5000 });
+      const i2 = await createIntent(user.id, { status: 'AWAITING_APPROVAL', subject: 'coffee maker', budget: 8900 });
+
+      await sendMenuCallback('menu_cancel_list', '_');
+
+      const [, , , opts] = mockEditMessageText.mock.calls[0];
+      const buttons = opts.reply_markup.inline_keyboard.flat();
+      const cancelButtons = buttons.filter((b: any) =>
+        b.callback_data?.startsWith('menu_cancel_confirm:'),
+      );
+      expect(cancelButtons).toHaveLength(2);
+      const payloads = cancelButtons.map((b: any) => b.callback_data.split(':')[1]);
+      expect(payloads).toContain(i1.id);
+      expect(payloads).toContain(i2.id);
+    });
+
+    it('shows empty state when no active intents', async () => {
+      const user = await createTestUser();
+      // Only DONE intents
+      await createIntent(user.id, { status: 'DONE' });
+
+      await sendMenuCallback('menu_cancel_list', '_');
+
+      const [, , text] = mockEditMessageText.mock.calls[0];
+      expect(text.toLowerCase()).toContain('no active intents');
+    });
+  });
+
+  // ── menu_cancel_confirm ─────────────────────────────────────────────────────
+
+  describe('menu_cancel_confirm callback', () => {
+    it('shows intent label, budget and confirm/back buttons', async () => {
+      const user = await createTestUser();
+      const intent = await createIntent(user.id, { status: 'SEARCHING', subject: 'headphones', budget: 5000 });
+
+      await sendMenuCallback('menu_cancel_confirm', intent.id);
+
+      const [, , text, opts] = mockEditMessageText.mock.calls[0];
+      expect(text).toContain('headphones');
+      expect(text).toContain('£50.00');
+
+      const buttons = opts.reply_markup.inline_keyboard.flat();
+      expect(buttons.some((b: any) => b.callback_data === `menu_cancel_do:${intent.id}`)).toBe(true);
+      expect(buttons.some((b: any) => b.callback_data === 'menu_cancel_list:_')).toBe(true);
+    });
+  });
+
+  // ── menu_cancel_do ──────────────────────────────────────────────────────────
+
+  describe('menu_cancel_do callback', () => {
+    it('transitions the intent to EXPIRED and confirms in the message', async () => {
+      const user = await createTestUser();
+      const intent = await createIntent(user.id, { status: 'SEARCHING' });
+
+      await sendMenuCallback('menu_cancel_do', intent.id);
+
+      // DB should reflect the cancellation
+      const updated = await prisma.purchaseIntent.findUnique({ where: { id: intent.id } });
+      expect(updated!.status).toBe('EXPIRED');
+
+      // Bot should confirm
+      const [, , text] = mockEditMessageText.mock.calls[0];
+      expect(text.toLowerCase()).toContain('cancelled');
+    });
+
+    it('returns reserved funds to user balance when a pot exists', async () => {
+      // Simulate the state after reserveForIntent: balance already decremented by the pot amount
+      const user = await createTestUser({ mainBalance: 7000 }); // 10000 - 3000 already reserved
+      // Put intent in APPROVED state (has a pot but no Stripe card)
+      const intent = await createIntent(user.id, { status: 'APPROVED', budget: 3000 });
+      await createPot(user.id, intent.id, 3000);
+
+      await sendMenuCallback('menu_cancel_do', intent.id);
+
+      await new Promise((r) => setTimeout(r, 200)); // allow pot return to settle
+
+      const updatedUser = await prisma.user.findUnique({ where: { id: user.id } });
+      // mainBalance should be restored: 7000 + 3000 = 10000
+      expect(updatedUser!.mainBalance).toBe(10000);
+    });
+
+    it('shows error message when intent does not exist', async () => {
+      await createTestUser();
+
+      await sendMenuCallback('menu_cancel_do', 'nonexistent-intent-id');
+
+      const [, , text] = mockEditMessageText.mock.calls[0];
+      expect(text.toLowerCase()).toContain('went wrong');
+    });
+  });
+
+  // ── menu_agent ──────────────────────────────────────────────────────────────
+
+  describe('menu_agent callback', () => {
+    it('shows linked agentId', async () => {
+      await createTestUser({ agentId: 'agent-xyz123' });
+
+      await sendMenuCallback('menu_agent', '_');
+
+      const [, , text] = mockEditMessageText.mock.calls[0];
+      expect(text).toContain('agent-xyz123');
+    });
+
+    it('shows /start prompt when no agent is linked', async () => {
+      await createTestUser({ agentId: null });
+
+      await sendMenuCallback('menu_agent', '_');
+
+      const [, , text] = mockEditMessageText.mock.calls[0];
+      expect(text).toContain('/start');
+    });
+  });
+
+  // ── menu_preferences ────────────────────────────────────────────────────────
+
+  describe('menu_preferences callback', () => {
+    it('shows the coming soon stub', async () => {
+      await createTestUser();
+
+      await sendMenuCallback('menu_preferences', '_');
+
+      const [, , text] = mockEditMessageText.mock.calls[0];
+      expect(text.toLowerCase()).toContain('coming soon');
+    });
+  });
+
+  // ── menu_main ───────────────────────────────────────────────────────────────
+
+  describe('menu_main callback', () => {
+    it('edits the message back to main menu with full keyboard', async () => {
+      await createTestUser();
+
+      await sendMenuCallback('menu_main', '_');
+
+      expect(mockEditMessageText).toHaveBeenCalledWith(
+        TEST_CHAT_ID,
+        TEST_MSG_ID,
+        expect.any(String),
+        expect.objectContaining({ reply_markup: expect.anything() }),
+      );
+
+      const keyboard = mockEditMessageText.mock.calls[0][3].reply_markup;
+      const allButtons = keyboard.inline_keyboard.flat();
+      expect(allButtons.length).toBeGreaterThanOrEqual(5);
+
+      const actions = allButtons.map((b: any) => b.callback_data);
+      expect(actions).toContain('menu_balance:_');
+      expect(actions).toContain('menu_history:_');
+      expect(actions).toContain('menu_cancel_list:_');
+      expect(actions).toContain('menu_agent:_');
+      expect(actions).toContain('menu_preferences:_');
+    });
+  });
+
+  // ── unknown menu_ action ────────────────────────────────────────────────────
+
+  describe('unknown menu_ callback', () => {
+    it('resolves without error (user found, action silently ignored)', async () => {
+      await createTestUser();
+
+      // Should not throw — webhook always returns 200
+      await sendMenuCallback('menu_nonexistent', '_');
+      // No crash = pass
+    });
+  });
+
+  // ── unauthenticated user for user-dependent actions ─────────────────────────
+
+  describe('user-dependent callbacks when user not found', () => {
+    it('menu_balance shows signup prompt when no user in DB', async () => {
+      // No user created
+      await sendMenuCallback('menu_balance', '_');
+
+      const [, , text] = mockEditMessageText.mock.calls[0];
+      expect(text.toLowerCase()).toContain('sign up');
+    });
+  });
+});

--- a/tests/unit/telegram/menuHandler.test.ts
+++ b/tests/unit/telegram/menuHandler.test.ts
@@ -1,0 +1,398 @@
+// Mock prisma before imports
+jest.mock('@/db/client', () => ({
+  prisma: {
+    user: { findFirst: jest.fn() },
+    pot: { findMany: jest.fn() },
+    purchaseIntent: { findMany: jest.fn(), findUnique: jest.fn() },
+  },
+}));
+
+// Mock Telegram bot
+const mockSendMessage = jest.fn().mockResolvedValue({ message_id: 99 });
+const mockEditMessageText = jest.fn().mockResolvedValue({});
+jest.mock('@/telegram/telegramClient', () => ({
+  getTelegramBot: () => ({
+    api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText },
+  }),
+}));
+
+// Mock expireIntent
+const mockExpireIntent = jest.fn();
+jest.mock('@/orchestrator/intentService', () => ({
+  expireIntent: (...args: any[]) => mockExpireIntent(...args),
+}));
+
+import { sendMainMenu, handleMenuCallback } from '@/telegram/menuHandler';
+import { prisma } from '@/db/client';
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+const chatId = 111222;
+const messageId = 99;
+const fromId = 111222;
+
+const baseUser = {
+  id: 'user-1',
+  telegramChatId: String(chatId),
+  email: 'alice@example.com',
+  agentId: 'agent-xyz123',
+  mainBalance: 12500, // £125.00
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockEditMessageText.mockResolvedValue({});
+  mockSendMessage.mockResolvedValue({ message_id: 99 });
+});
+
+// ── sendMainMenu ──────────────────────────────────────────────────────────────
+
+describe('sendMainMenu', () => {
+  it('sends main menu keyboard to chat', async () => {
+    (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);
+
+    await sendMainMenu(chatId);
+
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      chatId,
+      expect.any(String),
+      expect.objectContaining({ reply_markup: expect.anything() }),
+    );
+
+    const call = mockSendMessage.mock.calls[0];
+    const keyboard = call[2].reply_markup;
+    const allButtons = keyboard.inline_keyboard.flat();
+    // Expect at least 5 buttons
+    expect(allButtons.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('prompts signup when user not found', async () => {
+    (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(null);
+
+    await sendMainMenu(chatId);
+
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      chatId,
+      expect.stringContaining('sign up'),
+      expect.anything(),
+    );
+  });
+});
+
+// ── menu_balance ──────────────────────────────────────────────────────────────
+
+describe('menu_balance', () => {
+  it('shows main balance and reserved amount', async () => {
+    (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);
+    (mockPrisma.pot.findMany as jest.Mock).mockResolvedValue([{ reservedAmount: 2500 }]);
+
+    await handleMenuCallback(
+      { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+      chatId,
+      messageId,
+      'menu_balance',
+      '_',
+      fromId,
+    );
+
+    expect(mockEditMessageText).toHaveBeenCalledWith(
+      chatId,
+      messageId,
+      expect.stringContaining('£125.00'),
+      expect.anything(),
+    );
+    expect(mockEditMessageText).toHaveBeenCalledWith(
+      chatId,
+      messageId,
+      expect.stringContaining('£25.00'),
+      expect.anything(),
+    );
+  });
+
+  it('shows £0.00 reserved when no active pots', async () => {
+    (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);
+    (mockPrisma.pot.findMany as jest.Mock).mockResolvedValue([]);
+
+    await handleMenuCallback(
+      { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+      chatId,
+      messageId,
+      'menu_balance',
+      '_',
+      fromId,
+    );
+
+    expect(mockEditMessageText).toHaveBeenCalledWith(
+      chatId,
+      messageId,
+      expect.stringContaining('Reserved:     £0.00'),
+      expect.anything(),
+    );
+  });
+});
+
+// ── menu_history ──────────────────────────────────────────────────────────────
+
+describe('menu_history', () => {
+  it('shows last 5 DONE intents', async () => {
+    (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);
+    (mockPrisma.purchaseIntent.findMany as jest.Mock).mockResolvedValue([
+      { id: 'i1', subject: 'headphones', query: 'headphones', maxBudget: 4500, pot: { settledAmount: 4500 } },
+      { id: 'i2', subject: 'coffee maker', query: 'coffee', maxBudget: 8900, pot: { settledAmount: 8900 } },
+    ]);
+
+    await handleMenuCallback(
+      { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+      chatId,
+      messageId,
+      'menu_history',
+      '_',
+      fromId,
+    );
+
+    const text = mockEditMessageText.mock.calls[0][2] as string;
+    expect(text).toContain('headphones');
+    expect(text).toContain('£45.00');
+  });
+
+  it('shows empty state when no history', async () => {
+    (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);
+    (mockPrisma.purchaseIntent.findMany as jest.Mock).mockResolvedValue([]);
+
+    await handleMenuCallback(
+      { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+      chatId,
+      messageId,
+      'menu_history',
+      '_',
+      fromId,
+    );
+
+    const text = mockEditMessageText.mock.calls[0][2] as string;
+    expect(text.toLowerCase()).toContain('no purchases');
+  });
+});
+
+// ── menu_cancel_list ──────────────────────────────────────────────────────────
+
+describe('menu_cancel_list', () => {
+  it('renders one button per active intent', async () => {
+    (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);
+    (mockPrisma.purchaseIntent.findMany as jest.Mock).mockResolvedValue([
+      { id: 'i1', subject: 'headphones', query: 'headphones', maxBudget: 5000, status: 'SEARCHING' },
+      { id: 'i2', subject: 'coffee', query: 'coffee', maxBudget: 8900, status: 'AWAITING_APPROVAL' },
+    ]);
+
+    await handleMenuCallback(
+      { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+      chatId,
+      messageId,
+      'menu_cancel_list',
+      '_',
+      fromId,
+    );
+
+    const keyboard = mockEditMessageText.mock.calls[0][3].reply_markup;
+    const buttons = keyboard.inline_keyboard.flat();
+    const cancelButtons = buttons.filter((b: any) => b.callback_data?.startsWith('menu_cancel_confirm:'));
+    expect(cancelButtons).toHaveLength(2);
+  });
+
+  it('shows empty state when no active intents', async () => {
+    (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);
+    (mockPrisma.purchaseIntent.findMany as jest.Mock).mockResolvedValue([]);
+
+    await handleMenuCallback(
+      { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+      chatId,
+      messageId,
+      'menu_cancel_list',
+      '_',
+      fromId,
+    );
+
+    const text = mockEditMessageText.mock.calls[0][2] as string;
+    expect(text.toLowerCase()).toContain('no active intents');
+  });
+});
+
+// ── menu_cancel_confirm ───────────────────────────────────────────────────────
+
+describe('menu_cancel_confirm', () => {
+  it('shows intent details with confirm and back buttons', async () => {
+    (mockPrisma.purchaseIntent.findUnique as jest.Mock).mockResolvedValue({
+      id: 'i1',
+      subject: 'headphones',
+      query: 'headphones',
+      maxBudget: 5000,
+      status: 'SEARCHING',
+    });
+
+    await handleMenuCallback(
+      { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+      chatId,
+      messageId,
+      'menu_cancel_confirm',
+      'i1',
+      fromId,
+    );
+
+    const keyboard = mockEditMessageText.mock.calls[0][3].reply_markup;
+    const buttons = keyboard.inline_keyboard.flat();
+    const confirmBtn = buttons.find((b: any) => b.callback_data?.startsWith('menu_cancel_do:'));
+    const backBtn = buttons.find((b: any) => b.callback_data === 'menu_cancel_list:_');
+    expect(confirmBtn).toBeDefined();
+    expect(backBtn).toBeDefined();
+  });
+});
+
+// ── menu_cancel_do ────────────────────────────────────────────────────────────
+
+describe('menu_cancel_do', () => {
+  it('calls expireIntent with the intentId', async () => {
+    mockExpireIntent.mockResolvedValue({ status: 'EXPIRED' });
+
+    await handleMenuCallback(
+      { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+      chatId,
+      messageId,
+      'menu_cancel_do',
+      'intent-abc',
+      fromId,
+    );
+
+    expect(mockExpireIntent).toHaveBeenCalledWith('intent-abc');
+  });
+
+  it('edits message with confirmation on success', async () => {
+    mockExpireIntent.mockResolvedValue({ status: 'EXPIRED' });
+
+    await handleMenuCallback(
+      { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+      chatId,
+      messageId,
+      'menu_cancel_do',
+      'intent-abc',
+      fromId,
+    );
+
+    const text = mockEditMessageText.mock.calls[0][2] as string;
+    expect(text.toLowerCase()).toContain('cancelled');
+  });
+
+  it('shows error and does not rethrow when expireIntent throws', async () => {
+    mockExpireIntent.mockRejectedValue(new Error('fail'));
+
+    await expect(
+      handleMenuCallback(
+        { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+        chatId,
+        messageId,
+        'menu_cancel_do',
+        'intent-abc',
+        fromId,
+      ),
+    ).resolves.toBeUndefined();
+
+    const text = mockEditMessageText.mock.calls[0][2] as string;
+    expect(text.toLowerCase()).toContain('went wrong');
+  });
+});
+
+// ── menu_agent ────────────────────────────────────────────────────────────────
+
+describe('menu_agent', () => {
+  it('shows agentId when agent is linked', async () => {
+    (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);
+
+    await handleMenuCallback(
+      { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+      chatId,
+      messageId,
+      'menu_agent',
+      '_',
+      fromId,
+    );
+
+    const text = mockEditMessageText.mock.calls[0][2] as string;
+    expect(text).toContain('agent-xyz123');
+  });
+
+  it('prompts to link when no agent', async () => {
+    (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue({ ...baseUser, agentId: null });
+
+    await handleMenuCallback(
+      { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+      chatId,
+      messageId,
+      'menu_agent',
+      '_',
+      fromId,
+    );
+
+    const text = mockEditMessageText.mock.calls[0][2] as string;
+    expect(text).toContain('/start');
+  });
+});
+
+// ── menu_preferences ─────────────────────────────────────────────────────────
+
+describe('menu_preferences', () => {
+  it('shows coming soon stub', async () => {
+    await handleMenuCallback(
+      { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+      chatId,
+      messageId,
+      'menu_preferences',
+      '_',
+      fromId,
+    );
+
+    const text = mockEditMessageText.mock.calls[0][2] as string;
+    expect(text.toLowerCase()).toContain('coming soon');
+  });
+});
+
+// ── menu_main ─────────────────────────────────────────────────────────────────
+
+describe('menu_main', () => {
+  it('edits message back to main menu with keyboard', async () => {
+    await handleMenuCallback(
+      { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+      chatId,
+      messageId,
+      'menu_main',
+      '_',
+      fromId,
+    );
+
+    expect(mockEditMessageText).toHaveBeenCalledWith(
+      chatId,
+      messageId,
+      expect.any(String),
+      expect.objectContaining({ reply_markup: expect.anything() }),
+    );
+
+    const keyboard = mockEditMessageText.mock.calls[0][3].reply_markup;
+    const allButtons = keyboard.inline_keyboard.flat();
+    expect(allButtons.length).toBeGreaterThanOrEqual(5);
+  });
+});
+
+// ── unknown action ────────────────────────────────────────────────────────────
+
+describe('unknown menu_ action', () => {
+  it('resolves without throwing', async () => {
+    (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);
+
+    await expect(
+      handleMenuCallback(
+        { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+        chatId,
+        messageId,
+        'menu_unknown_action',
+        '_',
+        fromId,
+      ),
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Implements the `/menu` command for the Telegram bot (issue #23), giving users a full inline keyboard-driven interface to manage their account without leaving Telegram.

## What's new

**`/menu` command** — sends a 5-button main menu:
- 💰 **Balance** — main balance, reserved amount, available
- 📋 **History** — last 5 completed purchases
- 🚫 **Cancel Intent** — list active intents, confirm and cancel one
- 🔗 **Agent Status** — shows linked agent ID
- ⚙️ **Preferences** — coming soon stub (blocked on #21)

All navigation is edit-in-place (no new messages). Every screen has a ⬅️ Back button.

## Implementation

| File | Change |
|------|--------|
| `src/telegram/menuHandler.ts` | New — all menu logic |
| `src/telegram/signupHandler.ts` | Add `/menu` dispatch |
| `src/telegram/callbackHandler.ts` | Route `menu_*` callbacks to menuHandler |
| `docs/telegram-setup.md` | Document `/menu`, button reference table, troubleshooting |

## Tests

- **17 unit tests** (`tests/unit/telegram/menuHandler.test.ts`)
- **18 integration tests** (`tests/integration/telegram/menuHandler.test.ts`) — real DB, mocked Telegram
- **10-step interactive live test** (`tests/integration/telegram/menuHandler.live.test.ts`) — deletes webhook, polls `getUpdates`, waits for real button taps

## Notes

- Preferences screen is intentionally stubbed pending #21
- The live test restores the webhook after running