### PR TITLE
fix(security): add authorization and input validation for menu and preferences

### DIFF
--- a/src/api/routes/users.ts
+++ b/src/api/routes/users.ts
@@ -3,7 +3,8 @@ import { z } from 'zod';
 import { userAuthMiddleware } from '@/api/middleware/userAuth';
 import { prisma } from '@/db/client';
 import { expireIntent } from '@/orchestrator/intentService';
-import { IntentStatus, CardCancelPolicy } from '@/contracts';
+import { CardCancelPolicy } from '@/contracts';
+import { ACTIVE_STATES } from '@/orchestrator';
 
 const PreferencesSchema = z.object({
   cancelPolicy: z.nativeEnum(CardCancelPolicy).optional(),
@@ -17,16 +18,6 @@ const PreferencesSchema = z.object({
     });
   }
 });
-
-const ACTIVE_INTENT_STATUSES: IntentStatus[] = [
-  IntentStatus.RECEIVED,
-  IntentStatus.SEARCHING,
-  IntentStatus.QUOTED,
-  IntentStatus.AWAITING_APPROVAL,
-  IntentStatus.APPROVED,
-  IntentStatus.CARD_ISSUED,
-  IntentStatus.CHECKOUT_RUNNING,
-];
 
 export async function usersRoutes(fastify: FastifyInstance): Promise<void> {
   fastify.get('/v1/users/me', {
@@ -63,7 +54,7 @@ export async function usersRoutes(fastify: FastifyInstance): Promise<void> {
 
     // Cancel all non-terminal intents for this user (best-effort — continue even on partial failure)
     const activeIntents = await prisma.purchaseIntent.findMany({
-      where: { userId, status: { in: ACTIVE_INTENT_STATUSES } },
+      where: { userId, status: { in: [...ACTIVE_STATES] } },
       select: { id: true },
     });
 

--- a/src/api/routes/users.ts
+++ b/src/api/routes/users.ts
@@ -106,26 +106,37 @@ export async function usersRoutes(fastify: FastifyInstance): Promise<void> {
   });
 
   // PATCH /v1/users/:userId/preferences
-  // Update cancel policy and optional TTL. No auth required (internal/Telegram use).
-  fastify.patch('/v1/users/:userId/preferences', async (
+  // Update cancel policy and optional TTL. Requires authentication and ownership.
+  fastify.patch('/v1/users/:userId/preferences', {
+    preHandler: userAuthMiddleware,
+  }, async (
     request: FastifyRequest<{ Params: { userId: string } }>,
     reply: FastifyReply,
   ) => {
+    const authedUser = request.user!;
     const { userId } = request.params;
+
+    if (authedUser.id !== userId) {
+      return reply.status(403).send({ error: 'Forbidden: you may only update your own preferences' });
+    }
 
     const parsed = PreferencesSchema.safeParse(request.body);
     if (!parsed.success) {
       return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? 'Invalid request body' });
     }
 
-    const user = await prisma.user.findUnique({ where: { id: userId } });
-    if (!user) {
-      return reply.status(404).send({ error: 'User not found' });
-    }
-
     const updated = await prisma.user.update({
       where: { id: userId },
       data: parsed.data,
+    });
+
+    await prisma.auditEvent.create({
+      data: {
+        intentId: null,
+        actor: userId,
+        event: 'PREFERENCES_UPDATED',
+        payload: parsed.data as Record<string, unknown>,
+      },
     });
 
     return reply.send({

--- a/src/contracts/jobs.ts
+++ b/src/contracts/jobs.ts
@@ -17,3 +17,13 @@ export interface CheckoutIntentJob {
   stripeCardId: string;
   last4: string;
 }
+
+export interface CancelCardJob {
+  intentId: string;
+}
+
+export const QUEUE_NAMES = {
+  SEARCH: 'search-queue',
+  CHECKOUT: 'checkout-queue',
+  CANCEL_CARD: 'cancel-card-queue',
+} as const;

--- a/src/contracts/reconciliation.ts
+++ b/src/contracts/reconciliation.ts
@@ -1,13 +1,15 @@
+import { PotStatus } from './ledger';
+
 export interface ReconciliationReport {
   intentId: string;
   internal: {
     reserved: number;
     settled: number;
-    potStatus: string | null;
+    potStatus: PotStatus | null;
     ledgerEntries: string[]; // e.g. ["RESERVE:5000", "SETTLE:3500"]
   };
   stripe: {
-    cardStatus: string;
+    cardStatus: 'active' | 'inactive' | 'canceled';
     transactions: Array<{ id: string; amount: number; type: string }>;
     totalCaptured: number;
   } | null; // null if no VirtualCard exists for this intent

--- a/src/orchestrator/intentService.ts
+++ b/src/orchestrator/intentService.ts
@@ -1,5 +1,5 @@
 import { prisma } from '@/db/client';
-import { IntentEvent, PurchaseIntentData, AuditEventData, IntentNotFoundError } from '@/contracts';
+import { IntentEvent, PurchaseIntentData, AuditEventData, IntentNotFoundError, CardCancelPolicy } from '@/contracts';
 import { transitionIntent, TransitionResult } from './stateMachine';
 import { getPaymentProvider } from '@/payments';
 import { returnIntent } from '@/ledger/potService';
@@ -77,7 +77,7 @@ async function applyPostCheckoutCancelPolicy(intentId: string): Promise<void> {
 
   const { cancelPolicy, cardTtlMinutes, telegramChatId } = intent.user;
 
-  if (cancelPolicy === 'ON_TRANSACTION') {
+  if (cancelPolicy === CardCancelPolicy.ON_TRANSACTION) {
     // Cancellation is handled by the issuing_transaction.created Stripe webhook.
     // Fallback for stub/test flows where no real Stripe transaction fires:
     if (!intent.virtualCard) {
@@ -85,13 +85,13 @@ async function applyPostCheckoutCancelPolicy(intentId: string): Promise<void> {
         console.error(JSON.stringify({ level: 'error', message: 'ON_TRANSACTION stub fallback cancel failed', intentId, error: String(err) }));
       });
     }
-  } else if (cancelPolicy === 'IMMEDIATE') {
+  } else if (cancelPolicy === CardCancelPolicy.IMMEDIATE) {
     await getPaymentProvider().cancelCard(intentId).catch((err) => {
       console.error(JSON.stringify({ level: 'error', message: 'IMMEDIATE card cancel failed', intentId, error: String(err) }));
     });
-  } else if (cancelPolicy === 'AFTER_TTL' && cardTtlMinutes) {
+  } else if (cancelPolicy === CardCancelPolicy.AFTER_TTL && cardTtlMinutes) {
     await enqueueCancelCard(intentId, cardTtlMinutes * 60 * 1000);
-  } else if (cancelPolicy === 'MANUAL') {
+  } else if (cancelPolicy === CardCancelPolicy.MANUAL) {
     await getPaymentProvider().freezeCard(intentId).catch((err) => {
       console.error(JSON.stringify({ level: 'error', message: 'MANUAL card freeze failed', intentId, error: String(err) }));
     });

--- a/src/payments/providers/stripe/webhookHandler.ts
+++ b/src/payments/providers/stripe/webhookHandler.ts
@@ -3,6 +3,7 @@ import { getStripeClient } from './stripeClient';
 import { prisma } from '@/db/client';
 import { reconcileIntent } from './reconciliationService';
 import { getPaymentProvider } from '@/payments';
+import { CardCancelPolicy } from '@/contracts';
 
 export async function handleStripeEvent(rawBody: Buffer | string, signature: string): Promise<Record<string, unknown>> {
   const stripe = getStripeClient();
@@ -44,7 +45,7 @@ export async function handleStripeEvent(rawBody: Buffer | string, signature: str
         where: { id: intentId },
         include: { user: { select: { cancelPolicy: true } } },
       });
-      if (intentForPolicy?.user?.cancelPolicy === 'ON_TRANSACTION') {
+      if (intentForPolicy?.user?.cancelPolicy === CardCancelPolicy.ON_TRANSACTION) {
         getPaymentProvider().cancelCard(intentId).catch((err) => {
           console.error(JSON.stringify({ level: 'error', message: 'ON_TRANSACTION card cancel failed', intentId, error: String(err) }));
         });

--- a/src/queue/queues.ts
+++ b/src/queue/queues.ts
@@ -1,7 +1,8 @@
 import { Queue } from 'bullmq';
 import { getRedisConnectionConfig } from '@/config/redis';
+import { QUEUE_NAMES } from '@/contracts';
 
-export const searchQueue = new Queue('search-queue', {
+export const searchQueue = new Queue(QUEUE_NAMES.SEARCH, {
   connection: getRedisConnectionConfig(),
   defaultJobOptions: {
     attempts: 3,
@@ -11,7 +12,7 @@ export const searchQueue = new Queue('search-queue', {
   },
 });
 
-export const checkoutQueue = new Queue('checkout-queue', {
+export const checkoutQueue = new Queue(QUEUE_NAMES.CHECKOUT, {
   connection: getRedisConnectionConfig(),
   defaultJobOptions: {
     attempts: 3,
@@ -21,7 +22,7 @@ export const checkoutQueue = new Queue('checkout-queue', {
   },
 });
 
-export const cancelCardQueue = new Queue('cancel-card-queue', {
+export const cancelCardQueue = new Queue(QUEUE_NAMES.CANCEL_CARD, {
   connection: getRedisConnectionConfig(),
   defaultJobOptions: {
     attempts: 5,

--- a/src/telegram/callbackHandler.ts
+++ b/src/telegram/callbackHandler.ts
@@ -33,7 +33,8 @@ export async function handleTelegramCallback(update: Update): Promise<void> {
 
   // ── Menu callbacks ────────────────────────────────────────────────────────────
   if (action.startsWith('menu_')) {
-    await handleMenuCallback(bot, chatId!, messageId!, action, payload, fromId);
+    if (chatId === undefined || messageId === undefined) return;
+    await handleMenuCallback(bot, chatId, messageId, action, payload, fromId);
     return;
   }
 

--- a/src/telegram/menuHandler.ts
+++ b/src/telegram/menuHandler.ts
@@ -4,6 +4,7 @@ import { getTelegramBot } from './telegramClient';
 import { expireIntent } from '@/orchestrator/intentService';
 import { getPaymentProvider } from '@/payments';
 import { IntentStatus, CardCancelPolicy } from '@/contracts';
+import { ACTIVE_STATES } from '@/orchestrator';
 import { setPrefSession } from './sessionStore';
 
 const POLICY_LABELS: Record<CardCancelPolicy, string> = {
@@ -12,16 +13,6 @@ const POLICY_LABELS: Record<CardCancelPolicy, string> = {
   [CardCancelPolicy.AFTER_TTL]: 'After TTL',
   [CardCancelPolicy.MANUAL]: 'Manual',
 };
-
-const ACTIVE_INTENT_STATUSES: IntentStatus[] = [
-  IntentStatus.RECEIVED,
-  IntentStatus.SEARCHING,
-  IntentStatus.QUOTED,
-  IntentStatus.AWAITING_APPROVAL,
-  IntentStatus.APPROVED,
-  IntentStatus.CARD_ISSUED,
-  IntentStatus.CHECKOUT_RUNNING,
-];
 
 function formatAmount(amountInCents: number): string {
   return `£${(amountInCents / 100).toFixed(2)}`;
@@ -117,7 +108,7 @@ async function showCancelList(
   user: { id: string },
 ): Promise<void> {
   const intents = await prisma.purchaseIntent.findMany({
-    where: { userId: user.id, status: { in: ACTIVE_INTENT_STATUSES } },
+    where: { userId: user.id, status: { in: [...ACTIVE_STATES] } },
     orderBy: { createdAt: 'desc' },
   });
 

--- a/src/telegram/menuHandler.ts
+++ b/src/telegram/menuHandler.ts
@@ -143,12 +143,19 @@ async function showCancelConfirm(
   chatId: number | string,
   messageId: number,
   intentId: string,
+  userId: string,
 ): Promise<void> {
   const intent = await prisma.purchaseIntent.findUnique({ where: { id: intentId } });
 
   if (!intent) {
     const keyboard = new InlineKeyboard().text('⬅️ Back', 'menu_cancel_list:_');
     await editMenu(bot, chatId, messageId, '⚠️ Intent not found.', keyboard);
+    return;
+  }
+
+  if (intent.userId !== userId) {
+    const keyboard = new InlineKeyboard().text('⬅️ Back', 'menu_cancel_list:_');
+    await editMenu(bot, chatId, messageId, '⚠️ You do not have permission to cancel this intent.', keyboard);
     return;
   }
 
@@ -169,7 +176,19 @@ async function doCancelIntent(
   chatId: number | string,
   messageId: number,
   intentId: string,
+  userId: string,
 ): Promise<void> {
+  const intent = await prisma.purchaseIntent.findUnique({ where: { id: intentId }, select: { userId: true } });
+  if (!intent) {
+    const keyboard = new InlineKeyboard().text('⬅️ Back', 'menu_main:_');
+    await editMenu(bot, chatId, messageId, '⚠️ Intent not found.', keyboard);
+    return;
+  }
+  if (intent.userId !== userId) {
+    const keyboard = new InlineKeyboard().text('⬅️ Back', 'menu_main:_');
+    await editMenu(bot, chatId, messageId, '⚠️ You do not have permission to cancel this intent.', keyboard);
+    return;
+  }
   try {
     await expireIntent(intentId);
     const keyboard = new InlineKeyboard().text('⬅️ Back', 'menu_main:_');
@@ -295,7 +314,19 @@ async function doCancelCard(
   chatId: number | string,
   messageId: number,
   intentId: string,
+  userId: string,
 ): Promise<void> {
+  const intent = await prisma.purchaseIntent.findUnique({ where: { id: intentId }, select: { userId: true } });
+  if (!intent) {
+    const keyboard = new InlineKeyboard().text('⬅️ Back to Menu', 'menu_main:_');
+    await editMenu(bot, chatId, messageId, '⚠️ Intent not found.', keyboard);
+    return;
+  }
+  if (intent.userId !== userId) {
+    const keyboard = new InlineKeyboard().text('⬅️ Back to Menu', 'menu_main:_');
+    await editMenu(bot, chatId, messageId, '⚠️ You do not have permission to cancel this card.', keyboard);
+    return;
+  }
   try {
     await getPaymentProvider().cancelCard(intentId);
     const keyboard = new InlineKeyboard().text('⬅️ Back to Menu', 'menu_main:_');
@@ -343,21 +374,6 @@ export async function handleMenuCallback(
     return;
   }
 
-  if (action === 'menu_cancel_confirm') {
-    await showCancelConfirm(bot, chatId, messageId, payload);
-    return;
-  }
-
-  if (action === 'menu_cancel_do') {
-    await doCancelIntent(bot, chatId, messageId, payload);
-    return;
-  }
-
-  if (action === 'menu_card_cancel') {
-    await doCancelCard(bot, chatId, messageId, payload);
-    return;
-  }
-
   if (action === 'menu_pref_ttl' && payload === 'custom') {
     await startCustomTtlInput(bot, chatId, messageId);
     return;
@@ -377,7 +393,13 @@ export async function handleMenuCallback(
   }
 
   try {
-    if (action === 'menu_balance') {
+    if (action === 'menu_cancel_confirm') {
+      await showCancelConfirm(bot, chatId, messageId, payload, user.id);
+    } else if (action === 'menu_cancel_do') {
+      await doCancelIntent(bot, chatId, messageId, payload, user.id);
+    } else if (action === 'menu_card_cancel') {
+      await doCancelCard(bot, chatId, messageId, payload, user.id);
+    } else if (action === 'menu_balance') {
       await showBalance(bot, chatId, messageId, user);
     } else if (action === 'menu_history') {
       await showHistory(bot, chatId, messageId, user);
@@ -388,6 +410,10 @@ export async function handleMenuCallback(
     } else if (action === 'menu_preferences') {
       await showPreferences(bot, chatId, messageId, user);
     } else if (action === 'menu_pref_policy') {
+      if (!Object.values(CardCancelPolicy).includes(payload as CardCancelPolicy)) {
+        await editMenu(bot, chatId, messageId, '⚠️ Invalid policy value.');
+        return;
+      }
       const policy = payload as CardCancelPolicy;
       if (policy === CardCancelPolicy.AFTER_TTL) {
         await showTtlPicker(bot, chatId, messageId);

--- a/src/telegram/sessionStore.ts
+++ b/src/telegram/sessionStore.ts
@@ -37,6 +37,7 @@ const PREF_TTL_SECONDS = 300; // 5 minutes to reply with a number
 
 export interface PrefSession {
   awaitingCustomTtl: true;
+  promptMessageId?: number;
 }
 
 export async function getPrefSession(chatId: number | string): Promise<PrefSession | null> {

--- a/src/worker/processors/cancelCardProcessor.ts
+++ b/src/worker/processors/cancelCardProcessor.ts
@@ -1,14 +1,11 @@
 import { Worker, Job } from 'bullmq';
 import { getRedisConnectionConfig } from '@/config/redis';
 import { getPaymentProvider } from '@/payments';
-
-interface CancelCardJob {
-  intentId: string;
-}
+import { CancelCardJob, QUEUE_NAMES } from '@/contracts';
 
 export function createCancelCardWorker(): Worker {
   return new Worker(
-    'cancel-card-queue',
+    QUEUE_NAMES.CANCEL_CARD,
     async (job: Job<CancelCardJob>) => {
       const { intentId } = job.data;
       console.log(JSON.stringify({ level: 'info', message: 'Processing cancel card job', intentId }));

--- a/tests/integration/telegram/menuHandler.test.ts
+++ b/tests/integration/telegram/menuHandler.test.ts
@@ -8,6 +8,8 @@
  * Run: npm run test:integration -- --testPathPattern=telegram/menuHandler
  */
 
+import crypto from 'crypto';
+import bcrypt from 'bcryptjs';
 import { prisma } from '@/db/client';
 import { getRedisClient } from '@/config/redis';
 
@@ -479,12 +481,34 @@ testSuite('Telegram /menu integration (real DB)', () => {
   // ── PATCH /v1/users/:userId/preferences ─────────────────────────────────────
 
   describe('PATCH /v1/users/:userId/preferences', () => {
-    it('updates cancelPolicy and returns the new values', async () => {
-      const user = await createTestUser();
+    let rawKey: string;
+    let authHeader: string;
+    let authedUserId: string;
 
+    beforeEach(async () => {
+      rawKey = crypto.randomBytes(32).toString('hex');
+      const hash = await bcrypt.hash(rawKey, 10);
+      const prefix = rawKey.slice(0, 16);
+      const user = await prisma.user.create({
+        data: {
+          email: `pref-test-${Date.now()}@example.com`,
+          telegramChatId: String(TEST_CHAT_ID + 1),
+          agentId: null,
+          mainBalance: 10000,
+          maxBudgetPerIntent: 50000,
+          apiKeyHash: hash,
+          apiKeyPrefix: prefix,
+        },
+      });
+      authedUserId = user.id;
+      authHeader = `Bearer ${rawKey}`;
+    });
+
+    it('updates cancelPolicy and returns the new values', async () => {
       const res = await app.inject({
         method: 'PATCH',
-        url: `/v1/users/${user.id}/preferences`,
+        url: `/v1/users/${authedUserId}/preferences`,
+        headers: { authorization: authHeader },
         payload: { cancelPolicy: 'MANUAL' },
       });
 
@@ -492,16 +516,27 @@ testSuite('Telegram /menu integration (real DB)', () => {
       const body = JSON.parse(res.body);
       expect(body.cancelPolicy).toBe('MANUAL');
 
-      const updated = await prisma.user.findUnique({ where: { id: user.id } });
+      const updated = await prisma.user.findUnique({ where: { id: authedUserId } });
       expect(updated!.cancelPolicy).toBe('MANUAL');
     });
 
-    it('updates AFTER_TTL policy with cardTtlMinutes', async () => {
-      const user = await createTestUser();
+    it('writes an audit event on successful update', async () => {
+      await app.inject({
+        method: 'PATCH',
+        url: `/v1/users/${authedUserId}/preferences`,
+        headers: { authorization: authHeader },
+        payload: { cancelPolicy: 'IMMEDIATE' },
+      });
 
+      const audit = await prisma.auditEvent.findFirst({ where: { actor: authedUserId, event: 'PREFERENCES_UPDATED' } });
+      expect(audit).not.toBeNull();
+    });
+
+    it('updates AFTER_TTL policy with cardTtlMinutes', async () => {
       const res = await app.inject({
         method: 'PATCH',
-        url: `/v1/users/${user.id}/preferences`,
+        url: `/v1/users/${authedUserId}/preferences`,
+        headers: { authorization: authHeader },
         payload: { cancelPolicy: 'AFTER_TTL', cardTtlMinutes: 120 },
       });
 
@@ -512,11 +547,10 @@ testSuite('Telegram /menu integration (real DB)', () => {
     });
 
     it('returns 400 when cardTtlMinutes is set without AFTER_TTL policy', async () => {
-      const user = await createTestUser();
-
       const res = await app.inject({
         method: 'PATCH',
-        url: `/v1/users/${user.id}/preferences`,
+        url: `/v1/users/${authedUserId}/preferences`,
+        headers: { authorization: authHeader },
         payload: { cancelPolicy: 'IMMEDIATE', cardTtlMinutes: 60 },
       });
 
@@ -524,25 +558,50 @@ testSuite('Telegram /menu integration (real DB)', () => {
     });
 
     it('returns 400 for unknown cancelPolicy', async () => {
-      const user = await createTestUser();
-
       const res = await app.inject({
         method: 'PATCH',
-        url: `/v1/users/${user.id}/preferences`,
+        url: `/v1/users/${authedUserId}/preferences`,
+        headers: { authorization: authHeader },
         payload: { cancelPolicy: 'INVALID_POLICY' },
       });
 
       expect(res.statusCode).toBe(400);
     });
 
-    it('returns 404 for unknown userId', async () => {
+    it('returns 401 when no auth header provided', async () => {
       const res = await app.inject({
         method: 'PATCH',
-        url: '/v1/users/nonexistent-user-id/preferences',
+        url: `/v1/users/${authedUserId}/preferences`,
         payload: { cancelPolicy: 'IMMEDIATE' },
       });
 
-      expect(res.statusCode).toBe(404);
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('returns 403 when authed as a different user', async () => {
+      const otherRawKey = crypto.randomBytes(32).toString('hex');
+      const otherHash = await bcrypt.hash(otherRawKey, 10);
+      const otherPrefix = otherRawKey.slice(0, 16);
+      await prisma.user.create({
+        data: {
+          email: `other-${Date.now()}@example.com`,
+          telegramChatId: String(TEST_CHAT_ID + 2),
+          agentId: null,
+          mainBalance: 10000,
+          maxBudgetPerIntent: 50000,
+          apiKeyHash: otherHash,
+          apiKeyPrefix: otherPrefix,
+        },
+      });
+
+      const res = await app.inject({
+        method: 'PATCH',
+        url: `/v1/users/${authedUserId}/preferences`,
+        headers: { authorization: `Bearer ${otherRawKey}` },
+        payload: { cancelPolicy: 'IMMEDIATE' },
+      });
+
+      expect(res.statusCode).toBe(403);
     });
   });
 });

--- a/tests/unit/telegram/menuHandler.test.ts
+++ b/tests/unit/telegram/menuHandler.test.ts
@@ -243,8 +243,10 @@ describe('menu_cancel_list', () => {
 
 describe('menu_cancel_confirm', () => {
   it('shows intent details with confirm and back buttons', async () => {
+    (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);
     (mockPrisma.purchaseIntent.findUnique as jest.Mock).mockResolvedValue({
       id: 'i1',
+      userId: 'user-1',
       subject: 'headphones',
       query: 'headphones',
       maxBudget: 5000,
@@ -267,11 +269,40 @@ describe('menu_cancel_confirm', () => {
     expect(confirmBtn).toBeDefined();
     expect(backBtn).toBeDefined();
   });
+
+  it('shows permission error when intent belongs to a different user', async () => {
+    (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);
+    (mockPrisma.purchaseIntent.findUnique as jest.Mock).mockResolvedValue({
+      id: 'i1',
+      userId: 'other-user',
+      subject: 'headphones',
+      query: 'headphones',
+      maxBudget: 5000,
+      status: 'SEARCHING',
+    });
+
+    await handleMenuCallback(
+      { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+      chatId,
+      messageId,
+      'menu_cancel_confirm',
+      'i1',
+      fromId,
+    );
+
+    const text = mockEditMessageText.mock.calls[0][2] as string;
+    expect(text.toLowerCase()).toContain('permission');
+  });
 });
 
 // ── menu_cancel_do ────────────────────────────────────────────────────────────
 
 describe('menu_cancel_do', () => {
+  beforeEach(() => {
+    (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);
+    (mockPrisma.purchaseIntent.findUnique as jest.Mock).mockResolvedValue({ userId: 'user-1' });
+  });
+
   it('calls expireIntent with the intentId', async () => {
     mockExpireIntent.mockResolvedValue({ status: 'EXPIRED' });
 
@@ -319,6 +350,23 @@ describe('menu_cancel_do', () => {
 
     const text = mockEditMessageText.mock.calls[0][2] as string;
     expect(text.toLowerCase()).toContain('went wrong');
+  });
+
+  it('shows permission error when intent belongs to a different user', async () => {
+    (mockPrisma.purchaseIntent.findUnique as jest.Mock).mockResolvedValue({ userId: 'other-user' });
+
+    await handleMenuCallback(
+      { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+      chatId,
+      messageId,
+      'menu_cancel_do',
+      'intent-abc',
+      fromId,
+    );
+
+    expect(mockExpireIntent).not.toHaveBeenCalled();
+    const text = mockEditMessageText.mock.calls[0][2] as string;
+    expect(text.toLowerCase()).toContain('permission');
   });
 });
 
@@ -416,6 +464,19 @@ describe('menu_pref_policy', () => {
     expect(actions).toContain('menu_pref_ttl:30');
     expect(actions).toContain('menu_pref_ttl:custom');
   });
+
+  it('shows error when payload is not a valid CardCancelPolicy', async () => {
+    (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);
+
+    await handleMenuCallback(
+      { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+      chatId, messageId, 'menu_pref_policy', 'INVALID_POLICY', fromId,
+    );
+
+    expect(mockPrisma.user.update).not.toHaveBeenCalled();
+    const text = mockEditMessageText.mock.calls[0][2] as string;
+    expect(text.toLowerCase()).toContain('invalid');
+  });
 });
 
 // ── menu_pref_ttl ─────────────────────────────────────────────────────────────
@@ -457,6 +518,11 @@ describe('menu_pref_ttl', () => {
 // ── menu_card_cancel ──────────────────────────────────────────────────────────
 
 describe('menu_card_cancel', () => {
+  beforeEach(() => {
+    (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);
+    (mockPrisma.purchaseIntent.findUnique as jest.Mock).mockResolvedValue({ userId: 'user-1' });
+  });
+
   it('calls cancelCard and confirms', async () => {
     await handleMenuCallback(
       { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
@@ -478,6 +544,19 @@ describe('menu_card_cancel', () => {
 
     const text = mockEditMessageText.mock.calls[0][2] as string;
     expect(text.toLowerCase()).toContain('went wrong');
+  });
+
+  it('shows permission error when intent belongs to a different user', async () => {
+    (mockPrisma.purchaseIntent.findUnique as jest.Mock).mockResolvedValue({ userId: 'other-user' });
+
+    await handleMenuCallback(
+      { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+      chatId, messageId, 'menu_card_cancel', 'intent-abc', fromId,
+    );
+
+    expect(mockCancelCard).not.toHaveBeenCalled();
+    const text = mockEditMessageText.mock.calls[0][2] as string;
+    expect(text.toLowerCase()).toContain('permission');
   });
 });
 


### PR DESCRIPTION
Closes #91

## Summary

- **Intent ownership checks**: `menu_cancel_confirm`, `menu_cancel_do`, and `menu_card_cancel` now run after the user lookup and verify `intent.userId === user.id` before acting. Forged or replayed callback payloads from other users get an error menu instead.
- **Enum validation**: `menu_pref_policy` validates the payload against `Object.values(CardCancelPolicy)` before casting, preventing invalid values from being written to the DB.
- **Auth on preferences endpoint**: `PATCH /v1/users/:userId/preferences` now requires a valid Bearer token (`userAuthMiddleware`) and a matching `userId`. Returns 401 without auth, 403 for a different user. Writes a `PREFERENCES_UPDATED` audit event on success.
- **Null guard in callbackHandler**: Replaced `chatId!`/`messageId!` non-null asserts with an explicit `if (chatId === undefined || messageId === undefined) return;` guard to prevent silent runtime crashes on inline keyboard callbacks.

## Test plan

- [ ] All unit tests pass: `npm test -- --testPathPattern=tests/unit`
- [ ] New unit tests cover ownership failure (permission error message shown, action not taken) for all three cancel actions
- [ ] New unit test covers invalid `CardCancelPolicy` payload → error shown, no DB write
- [ ] Integration tests for preferences updated: now include auth setup, 401/403 coverage, and audit event assertion
- [ ] Integration tests require DB: `docker compose up -d && npm run test:integration -- --testPathPattern=telegram/menuHandler`