### PR TITLE
refactor(contracts): type system and contract cleanup (#92)

### DIFF
--- a/src/api/routes/users.ts
+++ b/src/api/routes/users.ts
@@ -3,7 +3,8 @@ import { z } from 'zod';
 import { userAuthMiddleware } from '@/api/middleware/userAuth';
 import { prisma } from '@/db/client';
 import { expireIntent } from '@/orchestrator/intentService';
-import { IntentStatus, CardCancelPolicy } from '@/contracts';
+import { CardCancelPolicy } from '@/contracts';
+import { ACTIVE_STATES } from '@/orchestrator';
 
 const PreferencesSchema = z.object({
   cancelPolicy: z.nativeEnum(CardCancelPolicy).optional(),
@@ -17,16 +18,6 @@ const PreferencesSchema = z.object({
     });
   }
 });
-
-const ACTIVE_INTENT_STATUSES: IntentStatus[] = [
-  IntentStatus.RECEIVED,
-  IntentStatus.SEARCHING,
-  IntentStatus.QUOTED,
-  IntentStatus.AWAITING_APPROVAL,
-  IntentStatus.APPROVED,
-  IntentStatus.CARD_ISSUED,
-  IntentStatus.CHECKOUT_RUNNING,
-];
 
 export async function usersRoutes(fastify: FastifyInstance): Promise<void> {
   fastify.get('/v1/users/me', {
@@ -63,7 +54,7 @@ export async function usersRoutes(fastify: FastifyInstance): Promise<void> {
 
     // Cancel all non-terminal intents for this user (best-effort — continue even on partial failure)
     const activeIntents = await prisma.purchaseIntent.findMany({
-      where: { userId, status: { in: ACTIVE_INTENT_STATUSES } },
+      where: { userId, status: { in: [...ACTIVE_STATES] } },
       select: { id: true },
     });
 

--- a/src/contracts/jobs.ts
+++ b/src/contracts/jobs.ts
@@ -17,3 +17,13 @@ export interface CheckoutIntentJob {
   stripeCardId: string;
   last4: string;
 }
+
+export interface CancelCardJob {
+  intentId: string;
+}
+
+export const QUEUE_NAMES = {
+  SEARCH: 'search-queue',
+  CHECKOUT: 'checkout-queue',
+  CANCEL_CARD: 'cancel-card-queue',
+} as const;

--- a/src/contracts/reconciliation.ts
+++ b/src/contracts/reconciliation.ts
@@ -1,13 +1,15 @@
+import { PotStatus } from './ledger';
+
 export interface ReconciliationReport {
   intentId: string;
   internal: {
     reserved: number;
     settled: number;
-    potStatus: string | null;
+    potStatus: PotStatus | null;
     ledgerEntries: string[]; // e.g. ["RESERVE:5000", "SETTLE:3500"]
   };
   stripe: {
-    cardStatus: string;
+    cardStatus: 'active' | 'inactive' | 'canceled';
     transactions: Array<{ id: string; amount: number; type: string }>;
     totalCaptured: number;
   } | null; // null if no VirtualCard exists for this intent

--- a/src/orchestrator/intentService.ts
+++ b/src/orchestrator/intentService.ts
@@ -1,5 +1,5 @@
 import { prisma } from '@/db/client';
-import { IntentEvent, PurchaseIntentData, AuditEventData, IntentNotFoundError } from '@/contracts';
+import { IntentEvent, PurchaseIntentData, AuditEventData, IntentNotFoundError, CardCancelPolicy } from '@/contracts';
 import { transitionIntent, TransitionResult } from './stateMachine';
 import { getPaymentProvider } from '@/payments';
 import { returnIntent } from '@/ledger/potService';
@@ -77,7 +77,7 @@ async function applyPostCheckoutCancelPolicy(intentId: string): Promise<void> {
 
   const { cancelPolicy, cardTtlMinutes, telegramChatId } = intent.user;
 
-  if (cancelPolicy === 'ON_TRANSACTION') {
+  if (cancelPolicy === CardCancelPolicy.ON_TRANSACTION) {
     // Cancellation is handled by the issuing_transaction.created Stripe webhook.
     // Fallback for stub/test flows where no real Stripe transaction fires:
     if (!intent.virtualCard) {
@@ -85,13 +85,13 @@ async function applyPostCheckoutCancelPolicy(intentId: string): Promise<void> {
         console.error(JSON.stringify({ level: 'error', message: 'ON_TRANSACTION stub fallback cancel failed', intentId, error: String(err) }));
       });
     }
-  } else if (cancelPolicy === 'IMMEDIATE') {
+  } else if (cancelPolicy === CardCancelPolicy.IMMEDIATE) {
     await getPaymentProvider().cancelCard(intentId).catch((err) => {
       console.error(JSON.stringify({ level: 'error', message: 'IMMEDIATE card cancel failed', intentId, error: String(err) }));
     });
-  } else if (cancelPolicy === 'AFTER_TTL' && cardTtlMinutes) {
+  } else if (cancelPolicy === CardCancelPolicy.AFTER_TTL && cardTtlMinutes) {
     await enqueueCancelCard(intentId, cardTtlMinutes * 60 * 1000);
-  } else if (cancelPolicy === 'MANUAL') {
+  } else if (cancelPolicy === CardCancelPolicy.MANUAL) {
     await getPaymentProvider().freezeCard(intentId).catch((err) => {
       console.error(JSON.stringify({ level: 'error', message: 'MANUAL card freeze failed', intentId, error: String(err) }));
     });

--- a/src/payments/providers/stripe/webhookHandler.ts
+++ b/src/payments/providers/stripe/webhookHandler.ts
@@ -3,6 +3,7 @@ import { getStripeClient } from './stripeClient';
 import { prisma } from '@/db/client';
 import { reconcileIntent } from './reconciliationService';
 import { getPaymentProvider } from '@/payments';
+import { CardCancelPolicy } from '@/contracts';
 
 export async function handleStripeEvent(rawBody: Buffer | string, signature: string): Promise<Record<string, unknown>> {
   const stripe = getStripeClient();
@@ -44,7 +45,7 @@ export async function handleStripeEvent(rawBody: Buffer | string, signature: str
         where: { id: intentId },
         include: { user: { select: { cancelPolicy: true } } },
       });
-      if (intentForPolicy?.user?.cancelPolicy === 'ON_TRANSACTION') {
+      if (intentForPolicy?.user?.cancelPolicy === CardCancelPolicy.ON_TRANSACTION) {
         getPaymentProvider().cancelCard(intentId).catch((err) => {
           console.error(JSON.stringify({ level: 'error', message: 'ON_TRANSACTION card cancel failed', intentId, error: String(err) }));
         });

--- a/src/queue/queues.ts
+++ b/src/queue/queues.ts
@@ -1,7 +1,8 @@
 import { Queue } from 'bullmq';
 import { getRedisConnectionConfig } from '@/config/redis';
+import { QUEUE_NAMES } from '@/contracts';
 
-export const searchQueue = new Queue('search-queue', {
+export const searchQueue = new Queue(QUEUE_NAMES.SEARCH, {
   connection: getRedisConnectionConfig(),
   defaultJobOptions: {
     attempts: 3,
@@ -11,7 +12,7 @@ export const searchQueue = new Queue('search-queue', {
   },
 });
 
-export const checkoutQueue = new Queue('checkout-queue', {
+export const checkoutQueue = new Queue(QUEUE_NAMES.CHECKOUT, {
   connection: getRedisConnectionConfig(),
   defaultJobOptions: {
     attempts: 3,
@@ -21,7 +22,7 @@ export const checkoutQueue = new Queue('checkout-queue', {
   },
 });
 
-export const cancelCardQueue = new Queue('cancel-card-queue', {
+export const cancelCardQueue = new Queue(QUEUE_NAMES.CANCEL_CARD, {
   connection: getRedisConnectionConfig(),
   defaultJobOptions: {
     attempts: 5,

--- a/src/telegram/menuHandler.ts
+++ b/src/telegram/menuHandler.ts
@@ -4,6 +4,7 @@ import { getTelegramBot } from './telegramClient';
 import { expireIntent } from '@/orchestrator/intentService';
 import { getPaymentProvider } from '@/payments';
 import { IntentStatus, CardCancelPolicy } from '@/contracts';
+import { ACTIVE_STATES } from '@/orchestrator';
 import { setPrefSession } from './sessionStore';
 
 const POLICY_LABELS: Record<CardCancelPolicy, string> = {
@@ -12,16 +13,6 @@ const POLICY_LABELS: Record<CardCancelPolicy, string> = {
   [CardCancelPolicy.AFTER_TTL]: 'After TTL',
   [CardCancelPolicy.MANUAL]: 'Manual',
 };
-
-const ACTIVE_INTENT_STATUSES: IntentStatus[] = [
-  IntentStatus.RECEIVED,
-  IntentStatus.SEARCHING,
-  IntentStatus.QUOTED,
-  IntentStatus.AWAITING_APPROVAL,
-  IntentStatus.APPROVED,
-  IntentStatus.CARD_ISSUED,
-  IntentStatus.CHECKOUT_RUNNING,
-];
 
 function formatAmount(amountInCents: number): string {
   return `£${(amountInCents / 100).toFixed(2)}`;
@@ -117,7 +108,7 @@ async function showCancelList(
   user: { id: string },
 ): Promise<void> {
   const intents = await prisma.purchaseIntent.findMany({
-    where: { userId: user.id, status: { in: ACTIVE_INTENT_STATUSES } },
+    where: { userId: user.id, status: { in: [...ACTIVE_STATES] } },
     orderBy: { createdAt: 'desc' },
   });
 

--- a/src/telegram/sessionStore.ts
+++ b/src/telegram/sessionStore.ts
@@ -37,6 +37,7 @@ const PREF_TTL_SECONDS = 300; // 5 minutes to reply with a number
 
 export interface PrefSession {
   awaitingCustomTtl: true;
+  promptMessageId?: number;
 }
 
 export async function getPrefSession(chatId: number | string): Promise<PrefSession | null> {

--- a/src/worker/processors/cancelCardProcessor.ts
+++ b/src/worker/processors/cancelCardProcessor.ts
@@ -1,14 +1,11 @@
 import { Worker, Job } from 'bullmq';
 import { getRedisConnectionConfig } from '@/config/redis';
 import { getPaymentProvider } from '@/payments';
-
-interface CancelCardJob {
-  intentId: string;
-}
+import { CancelCardJob, QUEUE_NAMES } from '@/contracts';
 
 export function createCancelCardWorker(): Worker {
   return new Worker(
-    'cancel-card-queue',
+    QUEUE_NAMES.CANCEL_CARD,
     async (job: Job<CancelCardJob>) => {
       const { intentId } = job.data;
       console.log(JSON.stringify({ level: 'info', message: 'Processing cancel card job', intentId }));


### PR DESCRIPTION
## Summary

- Add missing `promptMessageId?: number` to `PrefSession` interface
- Replace string literals (`'ON_TRANSACTION'` etc.) with `CardCancelPolicy` enum values in `intentService.ts` and `webhookHandler.ts`
- Move `CancelCardJob` interface and add `QUEUE_NAMES` constants to `src/contracts/jobs.ts`; update `queues.ts` and `cancelCardProcessor.ts` to import from contracts
- Remove duplicate `ACTIVE_INTENT_STATUSES` arrays in `users.ts` and `menuHandler.ts`; reuse `ACTIVE_STATES` from `@/orchestrator`
- Tighten `ReconciliationReport`: `potStatus` → `PotStatus | null`, `cardStatus` → `'active' | 'inactive' | 'canceled'`

Closes #92

## Test plan

- [ ] `npx tsc --noEmit` — no new type errors
- [ ] `npm test` — all 38 unit test suites pass