### PR TITLE
refactor(payments): expose createStripeProvider() test helper

### DIFF
--- a/src/payments/testHelpers.ts
+++ b/src/payments/testHelpers.ts
@@ -3,9 +3,20 @@
  * Import these only in test files — never in production code.
  */
 import { MockPaymentProvider } from './providers/mock/mockProvider';
+import { StripePaymentProvider } from './providers/stripe';
+import { getStripeClient } from './providers/stripe/stripeClient';
+import { runSimulatedCheckout } from './providers/stripe/checkoutSimulator';
 import { getPaymentProvider, resetPaymentProvider } from './providerFactory';
 
 export { resetPaymentProvider };
+
+export function createStripeProvider() {
+  return {
+    provider: new StripePaymentProvider(),
+    get stripe() { return getStripeClient(); },
+    runSimulatedCheckout,
+  };
+}
 
 export function getMockProvider(): MockPaymentProvider {
   const provider = getPaymentProvider();

--- a/tests/integration/e2e/checkoutSimulator.test.ts
+++ b/tests/integration/e2e/checkoutSimulator.test.ts
@@ -29,10 +29,10 @@
 
 import { prisma } from '@/db/client';
 import { getRedisClient } from '@/config/redis';
-import { issueVirtualCard, revealCard } from '@/payments/providers/stripe/cardService';
-import { runSimulatedCheckout } from '@/payments/providers/stripe/checkoutSimulator';
-import { getStripeClient } from '@/payments/providers/stripe/stripeClient';
+import { createStripeProvider } from '@/payments/testHelpers';
 import { IntentStatus } from '@/contracts';
+
+const stripeCtx = createStripeProvider();
 
 // Don't send real Telegram messages during tests
 jest.mock('@/telegram/telegramClient', () => ({
@@ -102,13 +102,13 @@ testSuite('Stripe Issuing card lifecycle + checkout simulation', () => {
     intentId = intent.id;
 
     // Issue the virtual card via Stripe Issuing (real API call)
-    await issueVirtualCard(intentId, 100, 'eur');
+    await stripeCtx.provider.issueCard(intentId, 100, 'eur');
 
     const card = await prisma.virtualCard.findUniqueOrThrow({ where: { intentId } });
     stripeCardId = card.stripeCardId;
 
     // Reveal credentials once — stored for all tests in this suite
-    const reveal = await revealCard(intentId);
+    const reveal = await stripeCtx.provider.revealCard(intentId);
     credentials = {
       number: reveal.number,
       cvc: reveal.cvc,
@@ -151,8 +151,7 @@ testSuite('Stripe Issuing card lifecycle + checkout simulation', () => {
     });
 
     it('card appears in Stripe as a virtual card with the correct spending limit', async () => {
-      const stripe = getStripeClient();
-      const stripeCard = await stripe.issuing.cards.retrieve(stripeCardId);
+      const stripeCard = await stripeCtx.stripe.issuing.cards.retrieve(stripeCardId);
 
       expect(stripeCard.type).toBe('virtual');
       expect(stripeCard.status).toBe('active');
@@ -177,10 +176,8 @@ testSuite('Stripe Issuing card lifecycle + checkout simulation', () => {
     });
 
     it('declines a test authorization that exceeds the €1 spending limit', async () => {
-      const stripe = getStripeClient();
-
       // Attempt €50 against a €1 limit — Stripe should decline immediately
-      const auth = await stripe.testHelpers.issuing.authorizations.create({
+      const auth = await stripeCtx.stripe.testHelpers.issuing.authorizations.create({
         card: stripeCardId,
         amount: 5000, // €50 — far exceeds the €1 limit
         currency: 'eur',
@@ -192,10 +189,8 @@ testSuite('Stripe Issuing card lifecycle + checkout simulation', () => {
     });
 
     it('approves and captures a test authorization within the €1 spending limit', async () => {
-      const stripe = getStripeClient();
-
       // Attempt €0.50 against a €1 limit — should be approved
-      const auth = await stripe.testHelpers.issuing.authorizations.create({
+      const auth = await stripeCtx.stripe.testHelpers.issuing.authorizations.create({
         card: stripeCardId,
         amount: 50, // €0.50 — within the €1 per_authorization limit
         currency: 'eur',
@@ -205,7 +200,7 @@ testSuite('Stripe Issuing card lifecycle + checkout simulation', () => {
       expect(auth.status).toBe('pending');
 
       // Capture creates an issuing_transaction and settles the authorization
-      const captured = await stripe.testHelpers.issuing.authorizations.capture(auth.id);
+      const captured = await stripeCtx.stripe.testHelpers.issuing.authorizations.capture(auth.id);
       expect(captured.status).toBe('closed');
     });
 
@@ -218,7 +213,7 @@ testSuite('Stripe Issuing card lifecycle + checkout simulation', () => {
 
   describe('runSimulatedCheckout via intentId (test helpers)', () => {
     it('declines when charge amount exceeds the spending limit', async () => {
-      const result = await runSimulatedCheckout({
+      const result = await stripeCtx.runSimulatedCheckout({
         intentId,
         amount: 5000, // €50 against €1 card — should be declined
         currency: 'eur',

--- a/tests/integration/e2e/telegramApprovalCheckout.test.ts
+++ b/tests/integration/e2e/telegramApprovalCheckout.test.ts
@@ -30,16 +30,17 @@ import { prisma } from '@/db/client';
 import { getRedisClient } from '@/config/redis';
 import { requestApproval, recordDecision } from '@/approval/approvalService';
 import { sendApprovalRequest } from '@/telegram/notificationService';
-import { issueVirtualCard } from '@/payments/providers/stripe/cardService';
+import { createStripeProvider } from '@/payments/testHelpers';
 import { reserveForIntent, settleIntent } from '@/ledger/potService';
 import {
   markCardIssued,
   startCheckout,
   completeCheckout,
 } from '@/orchestrator/intentService';
-import { getStripeClient } from '@/payments/providers/stripe/stripeClient';
 import { IntentStatus, ApprovalDecisionType } from '@/contracts';
 import { getTelegramMockCalls, clearTelegramMockCalls } from '@/telegram/mockBot';
+
+const stripeCtx = createStripeProvider();
 
 // -- Skip conditions ----------------------------------------------------------
 const hasStripeKey = process.env.STRIPE_SECRET_KEY?.startsWith('sk_test_');
@@ -172,7 +173,7 @@ testSuite('Telegram approval -> Stripe Issuing checkout', () => {
         // Mock mode: skip the 60 s wait and auto-approve immediately
         await recordDecision(intentId, ApprovalDecisionType.APPROVED, 'test-mock-approve');
         await reserveForIntent(userId, intentId, MAX_BUDGET);
-        await issueVirtualCard(intentId, MAX_BUDGET, CURRENCY);
+        await stripeCtx.provider.issueCard(intentId, MAX_BUDGET, CURRENCY);
         await markCardIssued(intentId);
         await startCheckout(intentId);
 
@@ -212,7 +213,7 @@ testSuite('Telegram approval -> Stripe Issuing checkout', () => {
         console.log('Timeout -- auto-approving and continuing...');
         await recordDecision(intentId, ApprovalDecisionType.APPROVED, 'test-auto-approve');
         await reserveForIntent(userId, intentId, MAX_BUDGET);
-        await issueVirtualCard(intentId, MAX_BUDGET, CURRENCY);
+        await stripeCtx.provider.issueCard(intentId, MAX_BUDGET, CURRENCY);
         await markCardIssued(intentId);
         await startCheckout(intentId);
         currentStatus = IntentStatus.CHECKOUT_RUNNING;
@@ -238,8 +239,7 @@ testSuite('Telegram approval -> Stripe Issuing checkout', () => {
     expect(card.stripeCardId).toMatch(/^ic_/);
     expect(card.last4).toHaveLength(4);
 
-    const stripe = getStripeClient();
-    const stripeCard = await stripe.issuing.cards.retrieve(card.stripeCardId);
+    const stripeCard = await stripeCtx.stripe.issuing.cards.retrieve(card.stripeCardId);
     expect(stripeCard.status).toBe('active');
     expect(stripeCard.spending_controls.spending_limits[0].amount).toBe(MAX_BUDGET);
 
@@ -258,9 +258,8 @@ testSuite('Telegram approval -> Stripe Issuing checkout', () => {
       await new Promise((r) => setTimeout(r, 3000));
 
       const card = await prisma.virtualCard.findUniqueOrThrow({ where: { intentId } });
-      const stripe = getStripeClient();
 
-      const auth = await stripe.testHelpers.issuing.authorizations.create({
+      const auth = await stripeCtx.stripe.testHelpers.issuing.authorizations.create({
         card: card.stripeCardId,
         amount: CHECKOUT_AMOUNT,
         currency: CURRENCY,
@@ -273,7 +272,7 @@ testSuite('Telegram approval -> Stripe Issuing checkout', () => {
         `Authorization approved: ${auth.id} (EUR${(CHECKOUT_AMOUNT / 100).toFixed(2)})`,
       );
 
-      const captured = await stripe.testHelpers.issuing.authorizations.capture(auth.id);
+      const captured = await stripeCtx.stripe.testHelpers.issuing.authorizations.capture(auth.id);
       expect(captured.status).toBe('closed');
       console.log(`Transaction captured.`);
     },


### PR DESCRIPTION
## Summary

- Adds `createStripeProvider()` to `src/payments/testHelpers.ts`, returning a `StripePaymentProvider` instance, a lazy `stripe` client getter, and `runSimulatedCheckout`
- Refactors `tests/integration/e2e/checkoutSimulator.test.ts` to use the new helper instead of importing from `@/payments/providers/stripe/cardService`, `checkoutSimulator`, and `stripeClient`
- Refactors `tests/integration/e2e/telegramApprovalCheckout.test.ts` similarly, removing its two internal stripe imports

Closes #38

## Test plan

- [ ] `npm test` — all unit tests pass
- [ ] `grep -r "@/payments/providers/stripe" tests/integration/e2e/` — no matches in the two refactored E2E files
- [ ] With `docker compose up -d` and a valid `STRIPE_SECRET_KEY=sk_test_*`: `npm run test:integration -- --testPathPattern=checkoutSimulator` and `--testPathPattern=telegramApprovalCheckout`