### PR TITLE
chore: add GitHub PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,47 @@
+## Summary
+
+<!-- What does this PR do? 1-3 sentences. Link the related issue: "Closes #123" -->
+
+Closes #
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / cleanup
+- [ ] Tests only
+- [ ] Docs / config
+
+## Module(s) affected
+
+<!-- Check all that apply. Each module owns its own directory — do not edit another module's files. -->
+
+- [ ] Contracts (`src/contracts/`)
+- [ ] DB / Prisma (`prisma/`, `src/db/`)
+- [ ] API Gateway (`src/api/`, `src/app.ts`)
+- [ ] Orchestrator (`src/orchestrator/`)
+- [ ] Payments (`src/payments/`)
+- [ ] Policy / Approval (`src/policy/`, `src/approval/`)
+- [ ] Ledger (`src/ledger/`)
+- [ ] Queue / Worker (`src/queue/`, `src/worker/`)
+- [ ] Telegram (`src/telegram/`)
+- [ ] Tests / QA
+- [ ] Docs / Tooling
+
+## Checklist
+
+- [ ] `npm test` passes locally
+- [ ] New or changed logic has unit tests
+- [ ] Integration tests added/updated if DB or Redis is touched
+- [ ] No PAN, CVC, or card expiry is logged or stored (security rule)
+- [ ] No new cross-module file edits (used function imports instead)
+- [ ] Types added/updated in `src/contracts/` if shared across modules
+- [ ] `.env.example` updated if new env vars are introduced
+
+## How to test
+
+<!-- Steps for the reviewer to verify this manually, e.g. seed data, curl commands, Stripe test mode steps -->
+
+## Notes for reviewer
+
+<!-- Anything non-obvious: tradeoffs made, known limitations, follow-up issues -->


### PR DESCRIPTION
## Summary

Adds a GitHub PR template so all contributors get a consistent, pre-filled form when opening a pull request.

Closes #24

## Type of change

- [x] Docs / config

## Module(s) affected

- [x] Docs / Tooling

## Checklist

- [x] No code changes — docs/config only

## Notes for reviewer

Template includes:
- Module ownership checklist mirroring CLAUDE.md's module boundaries table
- Explicit security checklist item for the PAN/CVC no-store rule
- Reminder to update `src/contracts/` for shared types
- Free-form "How to test" and "Notes for reviewer" sections