### PR TITLE
docs(issue-102): add CODEOWNERS and document branch protection rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# All files require review from at least one core contributor.
+# GitHub will automatically request reviews from this team on every PR.
+* @JonasBaeumer @georgyia @aleksandr-gorbunov @Hajuj

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing
+
+## Prerequisites
+
+- Node.js 20+
+- Docker (for local integration tests)
+
+## Getting started
+
+```bash
+git clone https://github.com/JonasBaeumer/trustedpaymentinfrastructureforagents.git
+cd trustedpaymentinfrastructureforagents
+cp .env.example .env        # fill in your values
+npm ci
+docker compose up -d        # start Postgres + Redis
+npx prisma migrate dev
+```
+
+## Branch protection (main)
+
+These rules are configured in **Settings → Branches** for the `main` branch:
+
+- Direct pushes disabled (require a pull request)
+- **Require at least 1 approving review** before merge
+- **Require review from Code Owners** (enforces `.github/CODEOWNERS`)
+- **Require signed commits** — all commits on the branch must be GPG- or SSH-signed
+- All CI status checks must pass
+
+The `.github/CODEOWNERS` file lists all four core contributors (`@JonasBaeumer`, `@georgyia`, `@aleksandr-gorbunov`, `@Hajuj`) as required reviewers for all files. GitHub will automatically request a review from the team on every PR and block merge until at least one approves.
+
+### Setting up commit signing
+
+If you haven't set up commit signing yet, the quickest path is SSH signing (Git ≥ 2.34):
+
+```bash
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/id_ed25519.pub
+git config --global commit.gpgsign true
+```
+
+Or with a GPG key — see [GitHub's guide](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+
+## Pull request checklist
+
+- [ ] Commits are signed
+- [ ] New behaviour is covered by tests


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` listing all four core contributors so GitHub auto-requests reviews on every PR and blocks merge until at least one approves
- Adds `CONTRIBUTING.md` documenting branch protection rules (required reviews, signed commits, CI checks) and a commit signing quickstart for SSH and GPG

## Test plan

- [ ] Open a test PR and verify GitHub automatically requests reviews from `@JonasBaeumer`, `@georgyia`, `@aleksandr-gorbunov`, and `@Hajuj`
- [ ] Verify merge is blocked without an approving review from a code owner

Closes #102