### PR TITLE
feat(telegram): add dedicated test channel for live integration tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,4 +19,8 @@ LOG_LEVEL=info
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_WEBHOOK_SECRET=
 TELEGRAM_TEST_CHAT_ID=
+# Separate Telegram group/channel for integration test messages (keeps your main bot chat clean).
+# Create a private Telegram group with yourself + the bot, then set its chat ID here.
+# Live integration tests will use this channel instead of TELEGRAM_TEST_CHAT_ID when set.
+TELEGRAM_TEST_CHANNEL_ID=
 TELEGRAM_MOCK=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ npm install
 # Database
 npm run db:migrate              # run pending migrations
 npm run db:reset                # reset and re-migrate (dev only)
-npm run seed                    # create demo@agentpay.dev (set TELEGRAM_TEST_CHAT_ID in .env to pre-link Telegram)
+npm run seed                    # create demo@agentpay.dev (set TELEGRAM_TEST_CHANNEL_ID or TELEGRAM_TEST_CHAT_ID in .env to pre-link Telegram)
 npx prisma studio               # browse DB in browser
 
 # Dev
@@ -134,7 +134,8 @@ STRIPE_WEBHOOK_SECRET=whsec_...
 WORKER_API_KEY=local-dev-worker-key
 TELEGRAM_BOT_TOKEN=...
 TELEGRAM_WEBHOOK_SECRET=...
-TELEGRAM_TEST_CHAT_ID=        # optional, local dev only
+TELEGRAM_TEST_CHAT_ID=        # optional, local dev only — your main bot DM chat ID
+TELEGRAM_TEST_CHANNEL_ID=     # optional, local dev only — separate group for integration test messages
 PORT=3000
 ```
 

--- a/README.md
+++ b/README.md
@@ -540,7 +540,8 @@ Copy `.env.example` to `.env` and fill in:
 | `WORKER_API_KEY` | Yes | `local-dev-worker-key` | Shared secret for agent endpoints |
 | `TELEGRAM_BOT_TOKEN` | No | — | Telegram bot token from @BotFather |
 | `TELEGRAM_WEBHOOK_SECRET` | No | — | Secret token for Telegram webhook verification |
-| `TELEGRAM_TEST_CHAT_ID` | No | — | Chat ID for local integration smoke tests |
+| `TELEGRAM_TEST_CHAT_ID` | No | — | Chat ID for local integration smoke tests (main bot DM) |
+| `TELEGRAM_TEST_CHANNEL_ID` | No | — | Chat ID of a separate Telegram group for integration test messages; routes live test traffic away from the main bot DM |
 | `PORT` | No | `3000` | HTTP listen port |
 | `NODE_ENV` | No | `development` | `development` / `test` / `production` |
 

--- a/docs/telegram-setup.md
+++ b/docs/telegram-setup.md
@@ -46,6 +46,8 @@ Restart the server after saving: `Ctrl+C` then `npm run dev`.
 
 > `TELEGRAM_TEST_CHAT_ID` is optional — used by Path A below to pre-link your Telegram account to the seeded demo user. Come back here at Path A Step 5.
 
+> `TELEGRAM_TEST_CHANNEL_ID` is optional — a **separate** chat for live integration tests (see [Test Channel Setup](#test-channel-setup) below). When set, all live test messages are routed there instead of your main bot chat, keeping the two conversations cleanly separated.
+
 ---
 
 ## Step 3 — Expose your local server with ngrok
@@ -222,6 +224,33 @@ Once a user is signed up, create an intent and run the stub worker (same as Path
 
 ---
 
+---
+
+## Test Channel Setup
+
+Live integration tests (e.g. `telegramApprovalCheckout`, `menuHandler.live`, `preferences.live`) send real Telegram messages. Without a dedicated test channel those messages land in your main bot conversation and clutter it.
+
+**One Telegram bot, two conversations** — a single bot can send messages to multiple chats. Create a private Telegram group that contains only you and the bot; that group gets its own chat ID and acts as an isolated test inbox.
+
+### Steps
+
+1. Open Telegram and create a new **group** (name it e.g. "AgentPay — Integration Tests").
+2. Add your bot to the group (search by its username).
+3. Find the group's chat ID. The easiest way: add [@userinfobot](https://t.me/userinfobot) to the group, it will print the group's numeric ID, then remove it. Alternatively, check the Telegram API: `GET https://api.telegram.org/bot<TOKEN>/getUpdates` after sending a message to the group.
+4. Add the ID to `.env`:
+   ```
+   TELEGRAM_TEST_CHANNEL_ID=<numeric-group-chat-id>
+   ```
+   Group chat IDs are negative numbers (e.g. `-1001234567890`).
+
+5. Restart the server: `Ctrl+C` then `npm run dev`.
+
+With `TELEGRAM_TEST_CHANNEL_ID` set, all live integration tests route to the group instead of your main bot DM. You still see the Approve/Reject buttons there and can tap them within the 60-second window — the test flow is identical.
+
+> `TELEGRAM_TEST_CHAT_ID` remains the fallback when `TELEGRAM_TEST_CHANNEL_ID` is not set, so existing setups keep working unchanged.
+
+---
+
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |
@@ -236,3 +265,5 @@ Once a user is signed up, create an intent and run the stub worker (same as Path
 | `POST /v1/users/:userId/link-telegram` returns 404 | userId is wrong or DB was reset | Re-run `npm run seed` and use the printed userId |
 | `/menu` gives no response | Webhook not registered or server not running | Re-run Step 4; ensure `npm run dev` is running |
 | `/menu` says "sign up first" | No account linked to your chat ID | Run `npm run seed` (with `TELEGRAM_TEST_CHAT_ID` set) or complete the `/start <code>` flow |
+| Live tests still post to my main bot chat | `TELEGRAM_TEST_CHANNEL_ID` not set | Add the group chat ID to `.env` and restart the server |
+| Integration test messages go to the wrong chat | Wrong chat ID value | Group IDs are negative numbers; copy the exact value from `@userinfobot` |

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -18,6 +18,7 @@ export const env = {
   TELEGRAM_BOT_TOKEN: process.env.TELEGRAM_BOT_TOKEN || '',
   TELEGRAM_WEBHOOK_SECRET: process.env.TELEGRAM_WEBHOOK_SECRET || '',
   TELEGRAM_TEST_CHAT_ID: process.env.TELEGRAM_TEST_CHAT_ID || '',
+  TELEGRAM_TEST_CHANNEL_ID: process.env.TELEGRAM_TEST_CHANNEL_ID || '',
   TELEGRAM_MOCK: process.env.TELEGRAM_MOCK === 'true',
   PAYMENT_PROVIDER: process.env.PAYMENT_PROVIDER || 'stripe',
   LOG_LEVEL: process.env.LOG_LEVEL || 'info',

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -9,10 +9,12 @@ const log = logger.child({ module: 'db/seed' });
 const prisma = new PrismaClient();
 
 async function main() {
-  // TELEGRAM_TEST_CHAT_ID lets you receive real Telegram notifications without going
-  // through the full OpenClaw pairing flow. Get your chat ID by messaging @userinfobot
-  // on Telegram, then add it to .env. Re-running the seed updates the existing user.
-  const telegramChatId = process.env.TELEGRAM_TEST_CHAT_ID || null;
+  // TELEGRAM_TEST_CHANNEL_ID (preferred) or TELEGRAM_TEST_CHAT_ID lets you receive real
+  // Telegram notifications without going through the full OpenClaw pairing flow.
+  // Get the chat ID by messaging @userinfobot on Telegram, then add it to .env.
+  // Re-running the seed updates the existing user.
+  const telegramChatId =
+    process.env.TELEGRAM_TEST_CHANNEL_ID || process.env.TELEGRAM_TEST_CHAT_ID || null;
 
   const rawKey = crypto.randomBytes(32).toString('hex');
   const apiKeyHash = await bcrypt.hash(rawKey, 10);
@@ -45,7 +47,7 @@ async function main() {
 
   const chatIdNote = user.telegramChatId
     ? user.telegramChatId
-    : '(not set — add TELEGRAM_TEST_CHAT_ID to .env and re-run seed to receive Telegram notifications)';
+    : '(not set — add TELEGRAM_TEST_CHANNEL_ID or TELEGRAM_TEST_CHAT_ID to .env and re-run seed to receive Telegram notifications)';
 
   log.info({ userId: user.id, email: user.email, telegramChatId: chatIdNote }, 'Seeded demo user');
   console.log(`Demo user API key (save this): ${rawKey}`);

--- a/tests/integration/e2e/telegramApprovalCheckout.test.ts
+++ b/tests/integration/e2e/telegramApprovalCheckout.test.ts
@@ -47,7 +47,8 @@ const isMockMode =
   process.env.TELEGRAM_MOCK === 'true' || !process.env.TELEGRAM_BOT_TOKEN;
 const hasTelegram =
   isMockMode ||
-  (!!process.env.TELEGRAM_BOT_TOKEN && !!process.env.TELEGRAM_TEST_CHAT_ID);
+  (!!process.env.TELEGRAM_BOT_TOKEN &&
+    !!(process.env.TELEGRAM_TEST_CHANNEL_ID || process.env.TELEGRAM_TEST_CHAT_ID));
 
 const testSuite = hasStripeKey && hasTelegram ? describe : describe.skip;
 
@@ -65,10 +66,10 @@ const CURRENCY = 'eur';
 const APPROVAL_TIMEOUT_MS = 60_000;
 const POLL_INTERVAL_MS = 2_000;
 
-// Use a synthetic chat ID in mock mode
+// Use a synthetic chat ID in mock mode; prefer the dedicated test channel over the main chat
 const TEST_CHAT_ID = isMockMode
   ? '999999999'
-  : process.env.TELEGRAM_TEST_CHAT_ID!;
+  : (process.env.TELEGRAM_TEST_CHANNEL_ID || process.env.TELEGRAM_TEST_CHAT_ID)!;
 
 // -- Teardown -----------------------------------------------------------------
 afterAll(async () => {

--- a/tests/integration/telegram/connectionFlow.test.ts
+++ b/tests/integration/telegram/connectionFlow.test.ts
@@ -21,7 +21,9 @@
  */
 
 const TELEGRAM_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
-const TELEGRAM_TEST_CHAT_ID = process.env.TELEGRAM_TEST_CHAT_ID;
+// Prefer the dedicated test channel to keep the main bot chat uncluttered
+const TELEGRAM_TEST_CHAT_ID =
+  process.env.TELEGRAM_TEST_CHANNEL_ID || process.env.TELEGRAM_TEST_CHAT_ID;
 const isMockEnv = process.env.TELEGRAM_MOCK === 'true';
 
 const describeIfTelegram =
@@ -145,7 +147,7 @@ describeIfTelegram('Telegram Bot API infrastructure', () => {
           }
         : () => {
             console.log(
-              'Step 3.1 skipped — set TELEGRAM_TEST_CHAT_ID in .env to enable',
+              'Step 3.1 skipped — set TELEGRAM_TEST_CHANNEL_ID or TELEGRAM_TEST_CHAT_ID in .env to enable',
             );
           },
     );

--- a/tests/integration/telegram/menuHandler.live.test.ts
+++ b/tests/integration/telegram/menuHandler.live.test.ts
@@ -43,9 +43,9 @@ import type { FastifyInstance } from 'fastify';
 // ── Environment ───────────────────────────────────────────────────────────────
 
 const TELEGRAM_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
-const TEST_CHAT_ID = process.env.TELEGRAM_TEST_CHAT_ID
-  ? parseInt(process.env.TELEGRAM_TEST_CHAT_ID, 10)
-  : null;
+// Prefer the dedicated test channel to keep the main bot chat uncluttered
+const _testChatIdRaw = process.env.TELEGRAM_TEST_CHANNEL_ID || process.env.TELEGRAM_TEST_CHAT_ID;
+const TEST_CHAT_ID = _testChatIdRaw ? parseInt(_testChatIdRaw, 10) : null;
 const TELEGRAM_SECRET = process.env.TELEGRAM_WEBHOOK_SECRET ?? 'ilovedatadogok';
 const BASE = `https://api.telegram.org/bot${TELEGRAM_TOKEN}`;
 const isMockEnv = process.env.TELEGRAM_MOCK === 'true';

--- a/tests/integration/telegram/preferences.live.test.ts
+++ b/tests/integration/telegram/preferences.live.test.ts
@@ -41,9 +41,9 @@ import type { FastifyInstance } from 'fastify';
 // ── Environment ───────────────────────────────────────────────────────────────
 
 const TELEGRAM_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
-const TEST_CHAT_ID = process.env.TELEGRAM_TEST_CHAT_ID
-  ? parseInt(process.env.TELEGRAM_TEST_CHAT_ID, 10)
-  : null;
+// Prefer the dedicated test channel to keep the main bot chat uncluttered
+const _testChatIdRaw = process.env.TELEGRAM_TEST_CHANNEL_ID || process.env.TELEGRAM_TEST_CHAT_ID;
+const TEST_CHAT_ID = _testChatIdRaw ? parseInt(_testChatIdRaw, 10) : null;
 const TELEGRAM_SECRET = process.env.TELEGRAM_WEBHOOK_SECRET ?? 'ilovedatadogok';
 const BASE = `https://api.telegram.org/bot${TELEGRAM_TOKEN}`;
 const isMockEnv = process.env.TELEGRAM_MOCK === 'true';

--- a/tests/setup.live.ts
+++ b/tests/setup.live.ts
@@ -1,2 +1,3 @@
 // Overrides setup.ts for live Telegram integration tests
+require('dotenv').config();
 process.env.TELEGRAM_MOCK = 'false';

--- a/tests/unit/api/rateLimit.test.ts
+++ b/tests/unit/api/rateLimit.test.ts
@@ -24,6 +24,7 @@ jest.mock('@/config/env', () => ({
     TELEGRAM_BOT_TOKEN: '',
     TELEGRAM_WEBHOOK_SECRET: 'test-telegram-secret',
     TELEGRAM_TEST_CHAT_ID: '',
+    TELEGRAM_TEST_CHANNEL_ID: '',
     TELEGRAM_MOCK: false,
     PAYMENT_PROVIDER: 'stripe',
   },

--- a/tests/unit/api/telegram.test.ts
+++ b/tests/unit/api/telegram.test.ts
@@ -10,6 +10,7 @@ jest.mock('@/config/env', () => ({
     TELEGRAM_BOT_TOKEN: 'test-bot-token',
     TELEGRAM_WEBHOOK_SECRET: 'test-webhook-secret',
     TELEGRAM_TEST_CHAT_ID: '',
+    TELEGRAM_TEST_CHANNEL_ID: '',
   },
 }));
 

--- a/tests/unit/telegram/callbackHandler.test.ts
+++ b/tests/unit/telegram/callbackHandler.test.ts
@@ -10,6 +10,7 @@ jest.mock('@/config/env', () => ({
     STRIPE_SECRET_KEY: 'sk_test_placeholder',
     STRIPE_WEBHOOK_SECRET: 'whsec_placeholder',
     TELEGRAM_TEST_CHAT_ID: '',
+    TELEGRAM_TEST_CHANNEL_ID: '',
   },
 }));
 

--- a/tests/unit/telegram/notificationService.test.ts
+++ b/tests/unit/telegram/notificationService.test.ts
@@ -10,6 +10,7 @@ jest.mock('@/config/env', () => ({
     STRIPE_SECRET_KEY: 'sk_test_placeholder',
     STRIPE_WEBHOOK_SECRET: 'whsec_placeholder',
     TELEGRAM_TEST_CHAT_ID: '',
+    TELEGRAM_TEST_CHANNEL_ID: '',
   },
 }));
 


### PR DESCRIPTION
## Summary

- Adds `TELEGRAM_TEST_CHANNEL_ID` env var pointing to a separate Telegram group (user + bot) used exclusively for live integration test messages, keeping them out of the main bot DM
- When set, all live integration tests (`telegramApprovalCheckout`, `menuHandler.live`, `preferences.live`, `connectionFlow`) route messages to the group instead; falls back to `TELEGRAM_TEST_CHAT_ID` so existing setups are unaffected
- Updates `src/db/seed.ts` to prefer `TELEGRAM_TEST_CHANNEL_ID` when linking the demo user's chat ID, using the same fallback pattern as the tests
- Adds `require('dotenv').config()` to `tests/setup.live.ts` so the live Jest config correctly loads `.env` vars (without this, `TELEGRAM_BOT_TOKEN` was never populated in the Jest process and all live tests were silently skipped)
- Adds `TELEGRAM_TEST_CHANNEL_ID: ''` to all four unit test env mocks to keep them in sync with the real env shape
- Documents the full group setup flow in `docs/telegram-setup.md` including how to obtain the group chat ID, with two new troubleshooting rows
- Updates `README.md`, `CLAUDE.md`, and `.env.example`

## Test plan

- [ ] Create a private Telegram group with yourself and the bot, make the bot an admin, set `TELEGRAM_TEST_CHANNEL_ID=<group-chat-id>` in `.env`
- [ ] `npx jest --config jest.integration.live.js --testPathPattern=connectionFlow --forceExit` — all 5 steps pass and the smoke test message appears in the group, not the main bot DM
- [ ] `npm test -- --testPathPattern=unit` — all 355 unit tests pass
- [ ] Verify that removing `TELEGRAM_TEST_CHANNEL_ID` and keeping only `TELEGRAM_TEST_CHAT_ID` still works (fallback behaviour)

Closes #83