### PR TITLE
feat(issue-17): propagate agentId into audit events and structured logs

### DIFF
--- a/prisma/migrations/20260418000000_add_audit_event_agent_id/migration.sql
+++ b/prisma/migrations/20260418000000_add_audit_event_agent_id/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable: add nullable agentId to AuditEvent so agent-triggered events can be
+-- distinguished per-agent. Populated from the X-Agent-Id header on /v1/agent/* routes.
+ALTER TABLE "AuditEvent" ADD COLUMN "agentId" TEXT;
+
+-- Index to support lookups of events by agent.
+CREATE INDEX "AuditEvent_agentId_idx" ON "AuditEvent"("agentId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -153,11 +153,14 @@ model AuditEvent {
   id        String   @id @default(cuid())
   intentId  String?
   actor     String
+  agentId   String?
   event     String
   payload   Json     @default("{}")
   createdAt DateTime @default(now())
 
   intent    PurchaseIntent? @relation(fields: [intentId], references: [id])
+
+  @@index([agentId])
 }
 
 model IdempotencyRecord {

--- a/src/api/middleware/agentContext.ts
+++ b/src/api/middleware/agentContext.ts
@@ -1,0 +1,24 @@
+import { FastifyRequest } from 'fastify';
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    agentId?: string;
+  }
+}
+
+export async function agentContextHook(request: FastifyRequest): Promise<void> {
+  const raw = request.headers['x-agent-id'];
+  const agentId = typeof raw === 'string' && raw.length > 0 ? raw : undefined;
+  request.agentId = agentId;
+
+  const params = request.params as { intentId?: string } | undefined;
+  const body = request.body as { intentId?: string } | undefined;
+  const intentId = params?.intentId ?? body?.intentId;
+  const route = request.routeOptions?.url ?? request.url;
+
+  request.log = request.log.child({
+    agentId: agentId ?? null,
+    intentId: intentId ?? null,
+    route,
+  });
+}

--- a/src/api/routes/agent.ts
+++ b/src/api/routes/agent.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { workerAuthMiddleware } from '@/api/middleware/auth';
+import { agentContextHook } from '@/api/middleware/agentContext';
 import { agentQuoteSchema, agentResultSchema, agentRegisterSchema } from '@/api/validators/agent';
 import { IntentStatus } from '@/contracts';
 import {
@@ -26,6 +27,10 @@ function generatePairingCode(): string {
 }
 
 export async function agentRoutes(fastify: FastifyInstance): Promise<void> {
+  // Enrich req.log with { agentId, intentId, route } and expose req.agentId to all handlers
+  // in this plugin scope. Runs after workerAuth so auth failures short-circuit first.
+  fastify.addHook('preHandler', agentContextHook);
+
   // POST /v1/agent/quote — worker posts search result
   // Flow: SEARCHING → QUOTED → AWAITING_APPROVAL
   fastify.post(
@@ -49,10 +54,10 @@ export async function agentRoutes(fastify: FastifyInstance): Promise<void> {
       }
 
       // SEARCHING → QUOTED (stores quote data in metadata via orchestrator)
-      await receiveQuote(intentId, { merchantName, merchantUrl, price, currency });
+      await receiveQuote(intentId, { merchantName, merchantUrl, price, currency }, request.agentId);
 
       // QUOTED → AWAITING_APPROVAL
-      await requestApproval(intentId);
+      await requestApproval(intentId, request.agentId);
 
       // Fire-and-forget Telegram notification — must not block the HTTP response
       sendApprovalRequest(intentId).catch((err: unknown) =>
@@ -91,10 +96,10 @@ export async function agentRoutes(fastify: FastifyInstance): Promise<void> {
       }
 
       if (success) {
-        await completeCheckout(intentId, actualAmount ?? 0);
+        await completeCheckout(intentId, actualAmount ?? 0, request.agentId);
         await settleIntent(intentId, actualAmount ?? 0);
       } else {
-        await failCheckout(intentId, errorMessage ?? 'Checkout failed');
+        await failCheckout(intentId, errorMessage ?? 'Checkout failed', request.agentId);
         await returnIntent(intentId);
       }
 
@@ -282,7 +287,7 @@ export async function agentRoutes(fastify: FastifyInstance): Promise<void> {
       preHandler: workerAuthMiddleware,
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
-      const agentId = request.headers['x-agent-id'] as string | undefined;
+      const agentId = request.agentId;
       if (!agentId) {
         return reply.status(400).send({ error: 'Missing X-Agent-Id header' });
       }

--- a/src/api/routes/users.ts
+++ b/src/api/routes/users.ts
@@ -109,6 +109,7 @@ export async function usersRoutes(fastify: FastifyInstance): Promise<void> {
           data: {
             intentId: null,
             actor: userId,
+            agentId,
             event: 'AGENT_UNLINKED',
             payload: { agentId, cancelledIntentIds },
           },

--- a/src/contracts/audit.ts
+++ b/src/contracts/audit.ts
@@ -2,6 +2,7 @@ export interface AuditEventData {
   id: string;
   intentId: string | null;
   actor: string;
+  agentId: string | null;
   event: string;
   payload: Record<string, unknown>;
   createdAt: Date;

--- a/src/orchestrator/intentService.ts
+++ b/src/orchestrator/intentService.ts
@@ -34,21 +34,25 @@ export async function startSearching(intentId: string): Promise<TransitionResult
 export async function receiveQuote(
   intentId: string,
   quotePayload: Record<string, unknown>,
+  agentId?: string,
 ): Promise<TransitionResult> {
   // Persist quote data in metadata so the approval route can read merchant/price info
   await prisma.purchaseIntent.update({
     where: { id: intentId },
     data: { metadata: quotePayload as any },
   });
-  return transitionIntent(intentId, IntentEvent.QUOTE_RECEIVED, quotePayload);
+  return transitionIntent(intentId, IntentEvent.QUOTE_RECEIVED, quotePayload, { agentId });
 }
 
-export async function requestApproval(intentId: string): Promise<TransitionResult> {
-  return transitionIntent(intentId, IntentEvent.APPROVAL_REQUESTED);
+export async function requestApproval(
+  intentId: string,
+  agentId?: string,
+): Promise<TransitionResult> {
+  return transitionIntent(intentId, IntentEvent.APPROVAL_REQUESTED, {}, { agentId });
 }
 
 export async function approveIntent(intentId: string, actorId: string): Promise<TransitionResult> {
-  return transitionIntent(intentId, IntentEvent.USER_APPROVED, {}, actorId);
+  return transitionIntent(intentId, IntentEvent.USER_APPROVED, {}, { actor: actorId });
 }
 
 export async function denyIntent(
@@ -56,22 +60,33 @@ export async function denyIntent(
   actorId: string,
   reason?: string,
 ): Promise<TransitionResult> {
-  return transitionIntent(intentId, IntentEvent.USER_DENIED, { reason }, actorId);
+  return transitionIntent(intentId, IntentEvent.USER_DENIED, { reason }, { actor: actorId });
 }
 
 export async function markCardIssued(intentId: string): Promise<TransitionResult> {
   return transitionIntent(intentId, IntentEvent.CARD_ISSUED);
 }
 
-export async function startCheckout(intentId: string): Promise<TransitionResult> {
-  return transitionIntent(intentId, IntentEvent.CHECKOUT_STARTED, {}, 'worker');
+export async function startCheckout(intentId: string, agentId?: string): Promise<TransitionResult> {
+  return transitionIntent(
+    intentId,
+    IntentEvent.CHECKOUT_STARTED,
+    {},
+    { actor: agentId ?? 'worker', agentId },
+  );
 }
 
 export async function completeCheckout(
   intentId: string,
   actualAmount: number,
+  agentId?: string,
 ): Promise<TransitionResult> {
-  const result = await transitionIntent(intentId, IntentEvent.CHECKOUT_SUCCEEDED, { actualAmount });
+  const result = await transitionIntent(
+    intentId,
+    IntentEvent.CHECKOUT_SUCCEEDED,
+    { actualAmount },
+    { agentId },
+  );
 
   // Apply cancel policy — fire-and-forget so policy errors never block the checkout response
   applyPostCheckoutCancelPolicy(intentId).catch((err) => {
@@ -144,8 +159,9 @@ async function notifyManualCardPending(
 export async function failCheckout(
   intentId: string,
   errorMessage: string,
+  agentId?: string,
 ): Promise<TransitionResult> {
-  return transitionIntent(intentId, IntentEvent.CHECKOUT_FAILED, { errorMessage });
+  return transitionIntent(intentId, IntentEvent.CHECKOUT_FAILED, { errorMessage }, { agentId });
 }
 
 async function cleanupExpiredIntent(intentId: string): Promise<void> {

--- a/src/orchestrator/stateMachine.ts
+++ b/src/orchestrator/stateMachine.ts
@@ -11,12 +11,23 @@ export interface TransitionResult {
   newStatus: IntentStatus;
 }
 
+export interface TransitionOptions {
+  actor?: string;
+  agentId?: string;
+}
+
 export async function transitionIntent(
   intentId: string,
   event: IntentEvent,
   payload: Record<string, unknown> = {},
-  actor: string = 'system',
+  options: TransitionOptions = {},
 ): Promise<TransitionResult> {
+  // When an agent triggers the transition, attribute the audit event to the agent:
+  // actor is the free-form subject string (agentId takes priority), agentId is the
+  // typed column kept in sync for querying/analytics.
+  const agentId = options.agentId;
+  const actor = options.actor ?? agentId ?? 'system';
+
   return await prisma.$transaction(async (tx) => {
     const intent = await tx.purchaseIntent.findUnique({ where: { id: intentId } });
     if (!intent) throw new IntentNotFoundError(intentId);
@@ -33,12 +44,13 @@ export async function transitionIntent(
       data: {
         intentId,
         actor,
+        agentId: agentId ?? null,
         event,
         payload: { previousStatus, newStatus, ...payload } as any,
       },
     });
 
-    log.info({ intentId, event, previousStatus, newStatus, actor }, 'Intent transition');
+    log.info({ intentId, event, previousStatus, newStatus, actor, agentId }, 'Intent transition');
 
     return {
       intent: updated as unknown as PurchaseIntentData,

--- a/src/telegram/signupHandler.ts
+++ b/src/telegram/signupHandler.ts
@@ -162,6 +162,7 @@ export async function handleTelegramMessage(update: Update): Promise<void> {
         data: {
           intentId: null,
           actor: user.id,
+          agentId: session.agentId,
           event: 'AGENT_LINKED',
           payload: { agentId: session.agentId, telegramChatId: chatId.toString() },
         },

--- a/tests/unit/api/agentContext.test.ts
+++ b/tests/unit/api/agentContext.test.ts
@@ -1,0 +1,72 @@
+import { agentContextHook } from '@/api/middleware/agentContext';
+
+describe('agentContextHook', () => {
+  function makeRequest(overrides: Record<string, unknown> = {}) {
+    const childLogger = { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() };
+    const childSpy = jest.fn().mockReturnValue(childLogger);
+    const baseLogger = { child: childSpy };
+    const req = {
+      headers: {},
+      params: {},
+      body: {},
+      url: '/v1/agent/quote',
+      routeOptions: { url: '/v1/agent/quote' },
+      log: baseLogger,
+      ...overrides,
+    } as any;
+    return { req, childSpy };
+  }
+
+  it('sets request.agentId from X-Agent-Id header', async () => {
+    const { req } = makeRequest({ headers: { 'x-agent-id': 'ag_abc123' } });
+    await agentContextHook(req);
+    expect(req.agentId).toBe('ag_abc123');
+  });
+
+  it('leaves request.agentId undefined when header is missing', async () => {
+    const { req } = makeRequest();
+    await agentContextHook(req);
+    expect(req.agentId).toBeUndefined();
+  });
+
+  it('treats empty X-Agent-Id string as missing', async () => {
+    const { req } = makeRequest({ headers: { 'x-agent-id': '' } });
+    await agentContextHook(req);
+    expect(req.agentId).toBeUndefined();
+  });
+
+  it('enriches req.log with agentId, intentId from params, and route', async () => {
+    const { req, childSpy } = makeRequest({
+      headers: { 'x-agent-id': 'ag_abc123' },
+      params: { intentId: 'intent-99' },
+      routeOptions: { url: '/v1/agent/card/:intentId' },
+    });
+    await agentContextHook(req);
+    expect(childSpy).toHaveBeenCalledWith({
+      agentId: 'ag_abc123',
+      intentId: 'intent-99',
+      route: '/v1/agent/card/:intentId',
+    });
+  });
+
+  it('falls back to intentId in request body when not in params', async () => {
+    const { req, childSpy } = makeRequest({
+      headers: { 'x-agent-id': 'ag_abc123' },
+      body: { intentId: 'intent-from-body' },
+    });
+    await agentContextHook(req);
+    expect(childSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ intentId: 'intent-from-body' }),
+    );
+  });
+
+  it('sets agentId and intentId to null in log fields when both are absent', async () => {
+    const { req, childSpy } = makeRequest();
+    await agentContextHook(req);
+    expect(childSpy).toHaveBeenCalledWith({
+      agentId: null,
+      intentId: null,
+      route: '/v1/agent/quote',
+    });
+  });
+});

--- a/tests/unit/api/unlinkAgent.test.ts
+++ b/tests/unit/api/unlinkAgent.test.ts
@@ -271,6 +271,7 @@ describe('POST /v1/users/:userId/unlink-agent', () => {
         data: expect.objectContaining({
           intentId: null,
           actor: 'user-1',
+          agentId: 'ag_linked',
           event: 'AGENT_UNLINKED',
           payload: expect.objectContaining({ agentId: 'ag_linked' }),
         }),

--- a/tests/unit/api/wiring.test.ts
+++ b/tests/unit/api/wiring.test.ts
@@ -359,8 +359,38 @@ describe('POST /v1/agent/quote wiring', () => {
         merchantUrl: 'https://amazon.co.uk',
         price: 9999,
       }),
+      undefined,
     );
-    expect(mockRequestApproval).toHaveBeenCalledWith('intent-q1');
+    expect(mockRequestApproval).toHaveBeenCalledWith('intent-q1', undefined);
+  });
+
+  it('propagates X-Agent-Id header to receiveQuote and requestApproval', async () => {
+    seedSearchingIntent('intent-q-agent');
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/agent/quote',
+      headers: {
+        'content-type': 'application/json',
+        'x-worker-key': 'test-worker-key',
+        'x-agent-id': 'ag_from_header',
+      },
+      body: JSON.stringify({
+        intentId: 'intent-q-agent',
+        merchantName: 'X',
+        merchantUrl: 'https://x.com',
+        price: 100,
+        currency: 'gbp',
+      }),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockReceiveQuote).toHaveBeenCalledWith(
+      'intent-q-agent',
+      expect.any(Object),
+      'ag_from_header',
+    );
+    expect(mockRequestApproval).toHaveBeenCalledWith('intent-q-agent', 'ag_from_header');
   });
 
   it('does NOT call receiveQuote for non-SEARCHING intent', async () => {
@@ -686,7 +716,7 @@ describe('POST /v1/agent/result wiring — success', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(mockCompleteCheckout).toHaveBeenCalledWith('intent-r1', 8000);
+    expect(mockCompleteCheckout).toHaveBeenCalledWith('intent-r1', 8000, undefined);
     expect(mockSettleIntent).toHaveBeenCalledWith('intent-r1', 8000);
     expect(mockFailCheckout).not.toHaveBeenCalled();
     expect(mockReturnIntent).not.toHaveBeenCalled();
@@ -739,10 +769,27 @@ describe('POST /v1/agent/result wiring — failure', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(mockFailCheckout).toHaveBeenCalledWith('intent-f1', 'Payment declined');
+    expect(mockFailCheckout).toHaveBeenCalledWith('intent-f1', 'Payment declined', undefined);
     expect(mockReturnIntent).toHaveBeenCalledWith('intent-f1');
     expect(mockCompleteCheckout).not.toHaveBeenCalled();
     expect(mockSettleIntent).not.toHaveBeenCalled();
+  });
+
+  it('propagates X-Agent-Id header to failCheckout', async () => {
+    seedRunningIntent('intent-f-agent');
+
+    await app.inject({
+      method: 'POST',
+      url: '/v1/agent/result',
+      headers: {
+        'content-type': 'application/json',
+        'x-worker-key': 'test-worker-key',
+        'x-agent-id': 'ag_from_header',
+      },
+      body: JSON.stringify({ intentId: 'intent-f-agent', success: false, errorMessage: 'nope' }),
+    });
+
+    expect(mockFailCheckout).toHaveBeenCalledWith('intent-f-agent', 'nope', 'ag_from_header');
   });
 
   it('calls cancelCard after failed checkout', async () => {

--- a/tests/unit/orchestrator/transitionIntent.test.ts
+++ b/tests/unit/orchestrator/transitionIntent.test.ts
@@ -93,4 +93,72 @@ describe('transitionIntent', () => {
       }),
     );
   });
+
+  describe('actor attribution', () => {
+    function runTransition() {
+      const mockIntent = { id: 'intent-1', status: IntentStatus.RECEIVED };
+      const auditCreateMock = jest.fn().mockResolvedValue({});
+      (mockPrisma.$transaction as jest.Mock).mockImplementation(async (fn: Function) => {
+        const txMock = {
+          purchaseIntent: {
+            findUnique: jest.fn().mockResolvedValue(mockIntent),
+            update: jest.fn().mockResolvedValue({ ...mockIntent, status: IntentStatus.SEARCHING }),
+          },
+          auditEvent: { create: auditCreateMock },
+        };
+        return fn(txMock);
+      });
+      return { auditCreateMock };
+    }
+
+    it('defaults actor to "system" and agentId to null when no options passed', async () => {
+      const { auditCreateMock } = runTransition();
+      await transitionIntent('intent-1', IntentEvent.INTENT_CREATED);
+      expect(auditCreateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ actor: 'system', agentId: null }),
+        }),
+      );
+    });
+
+    it('uses agentId as actor and populates agentId column when only agentId provided', async () => {
+      const { auditCreateMock } = runTransition();
+      await transitionIntent('intent-1', IntentEvent.INTENT_CREATED, {}, { agentId: 'ag_abc123' });
+      expect(auditCreateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ actor: 'ag_abc123', agentId: 'ag_abc123' }),
+        }),
+      );
+    });
+
+    it('keeps explicit actor (e.g. user) and still records agentId separately', async () => {
+      const { auditCreateMock } = runTransition();
+      await transitionIntent(
+        'intent-1',
+        IntentEvent.INTENT_CREATED,
+        {},
+        { actor: 'user-1', agentId: 'ag_abc123' },
+      );
+      expect(auditCreateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ actor: 'user-1', agentId: 'ag_abc123' }),
+        }),
+      );
+    });
+
+    it('uses explicit actor without agentId when agent is not involved', async () => {
+      const { auditCreateMock } = runTransition();
+      await transitionIntent(
+        'intent-1',
+        IntentEvent.INTENT_CREATED,
+        {},
+        { actor: 'approval-service' },
+      );
+      expect(auditCreateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ actor: 'approval-service', agentId: null }),
+        }),
+      );
+    });
+  });
 });


### PR DESCRIPTION
Closes #17.

## Summary
- Add nullable `AuditEvent.agentId` column (with index) via migration
- New `agentContextHook` middleware reads `X-Agent-Id` on all `/v1/agent/*` routes, exposes `request.agentId` to handlers, and enriches `req.log` with `{ agentId, intentId, route }`
- `transitionIntent` takes `{ actor, agentId }` options; `actor` falls back to `agentId` so agent-driven transitions self-attribute in `AuditEvent.actor`
- Agent route handlers (`/v1/agent/quote`, `/v1/agent/result`) thread `request.agentId` into `receiveQuote`, `requestApproval`, `completeCheckout`, `failCheckout`
- `GET /v1/debug/audit/:intentId` returns the new `agentId` field automatically (Prisma returns all scalars)
- `AGENT_LINKED` and `AGENT_UNLINKED` events also populate the column for consistency

## Acceptance criteria
- [x] AuditEvent.actor for agent-triggered events contains the agentId
- [x] GET /v1/debug/audit/:intentId returns agentId per event
- [x] Structured log lines on agent routes include { agentId, intentId, route }
- [x] Schema migration adds nullable agentId to AuditEvent
- [x] Unit test for actor attribution logic

## Test plan
- [x] `npx jest tests/unit/orchestrator/transitionIntent.test.ts` — 4 new actor-attribution cases (default / agent-only / agent+explicit-user / explicit-actor-only)
- [x] `npx jest tests/unit/api/agentContext.test.ts` — 6 cases for the header extraction + log enrichment
- [x] `npx jest tests/unit/api/wiring.test.ts` — route-level tests that `X-Agent-Id` propagates into orchestrator calls
- [x] `npx jest tests/unit/api/unlinkAgent.test.ts` — updated to assert the new `agentId` column on `AGENT_UNLINKED`
- [ ] Manual: run `docker compose up -d && npm run db:migrate && npm run dev`, post a quote with `X-Agent-Id: ag_test`, then `GET /v1/debug/audit/:intentId` and confirm `agentId` appears per event and log lines include the agent context