### PR TITLE
feat(issue-106): Privacy.com integration + signup provider choice

### DIFF
--- a/prisma/migrations/20260418100000_add_privacy_com_provider/migration.sql
+++ b/prisma/migrations/20260418100000_add_privacy_com_provider/migration.sql
@@ -1,0 +1,4 @@
+-- Add PRIVACY_COM to the PaymentProvider enum.
+-- Must run outside a transaction in older Postgres; ALTER TYPE ... ADD VALUE
+-- is transactional on Postgres 12+, which is fine for our target.
+ALTER TYPE "PaymentProvider" ADD VALUE 'PRIVACY_COM';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,6 +47,7 @@ enum CardCancelPolicy {
 
 enum PaymentProvider {
   STRIPE
+  PRIVACY_COM
 }
 
 model User {

--- a/src/api/routes/webhooks.ts
+++ b/src/api/routes/webhooks.ts
@@ -1,11 +1,12 @@
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { env } from '@/config/env';
 import { getPaymentProvider } from '@/payments';
 import { PaymentProvider } from '@/contracts';
 
 export async function webhookRoutes(fastify: FastifyInstance): Promise<void> {
-  // Raw body is preserved for this path by app's content-type parser (required for Stripe signature verification).
-  // The route hardcodes PaymentProvider.STRIPE because each provider has its own webhook path
-  // with provider-specific signature schemes (Privacy.com will add /v1/webhooks/privacy in #106).
+  // Each provider gets its own webhook route because signature schemes are provider-specific.
+  // Raw body preservation is configured in app.ts for these paths (required for HMAC verification).
+
   fastify.post(
     '/v1/webhooks/stripe',
     {
@@ -38,6 +39,39 @@ export async function webhookRoutes(fastify: FastifyInstance): Promise<void> {
       // Stripe requires the Stripe-Version header in responses to issuing_authorization.request.
       // Without it Stripe reports "Invalid Stripe API version: " and declines the authorization.
       return reply.header('Stripe-Version', '2024-06-20').send(response);
+    },
+  );
+
+  fastify.post(
+    '/v1/webhooks/privacy',
+    {
+      config: {
+        rateLimit: {
+          max: 500,
+          timeWindow: '1 minute',
+          keyGenerator: (req: FastifyRequest) => req.ip ?? 'unknown',
+        },
+      },
+    },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const signatureHeader = env.PRIVACY_WEBHOOK_SIGNATURE_HEADER;
+      const signature = request.headers[signatureHeader] as string | undefined;
+      if (!signature) {
+        return reply.status(400).send({ error: `Missing ${signatureHeader} header` });
+      }
+
+      let response: Record<string, unknown> = { received: true };
+      try {
+        const body = request.body as Buffer | string;
+        response = await getPaymentProvider(PaymentProvider.PRIVACY_COM).handleWebhookEvent(
+          body,
+          signature,
+        );
+      } catch (err) {
+        fastify.log.error({ message: 'Privacy.com webhook processing error', error: String(err) });
+      }
+
+      return reply.send(response);
     },
   );
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,11 +19,12 @@ export function buildApp() {
     trustProxy: true,
   });
 
-  // Register content-type parser: for Stripe webhook path pass raw buffer (required for
+  // Register content-type parser: for provider webhook paths pass raw buffer (required for
   // signature verification); for all other application/json parse as JSON.
+  const RAW_BODY_PATHS = new Set(['/v1/webhooks/stripe', '/v1/webhooks/privacy']);
   fastify.addContentTypeParser('application/json', { parseAs: 'buffer' }, (req, body, done) => {
     const path = req.url?.split('?')[0];
-    if (path === '/v1/webhooks/stripe') {
+    if (path && RAW_BODY_PATHS.has(path)) {
       done(null, body);
       return;
     }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -12,6 +12,11 @@ export const env = {
   REDIS_URL: requireEnv('REDIS_URL'),
   STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY || 'sk_test_placeholder',
   STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET || 'whsec_placeholder',
+  PRIVACY_API_KEY: process.env.PRIVACY_API_KEY || 'privacy_test_placeholder',
+  PRIVACY_API_BASE_URL: process.env.PRIVACY_API_BASE_URL || 'https://api.privacy.com/v1',
+  PRIVACY_WEBHOOK_SECRET: process.env.PRIVACY_WEBHOOK_SECRET || 'privacy_whsec_placeholder',
+  PRIVACY_WEBHOOK_SIGNATURE_HEADER:
+    process.env.PRIVACY_WEBHOOK_SIGNATURE_HEADER || 'x-privacy-signature',
   WORKER_API_KEY: requireEnv('WORKER_API_KEY'),
   PORT: parseInt(process.env.PORT || '3000', 10),
   NODE_ENV: process.env.NODE_ENV || 'development',

--- a/src/contracts/payment.ts
+++ b/src/contracts/payment.ts
@@ -3,11 +3,41 @@ import { PaymentProvider } from '@prisma/client';
 export { PaymentProvider };
 
 /**
- * Describes a payment provider's defaults. Additional fields
- * (displayName, authorizationModel, autoCancelAfterUse, supportsFreeze)
- * will be added alongside their first consumer in the Privacy.com PR (#106).
+ * Describes a payment provider's defaults and capabilities. Callers consult
+ * this instead of hardcoding provider-specific behavior (currency, auth model,
+ * which operations are supported).
  */
 export interface ProviderMetadata {
   id: PaymentProvider;
+  displayName: string;
   currency: string;
+  /**
+   * Whether the provider fires a synchronous per-transaction authorization
+   * hook (Stripe's `issuing_authorization.request`) or commits at card
+   * creation time with no per-transaction approve/deny (Privacy.com).
+   */
+  authorizationModel: 'per_transaction' | 'fire_and_forget';
+  /**
+   * Whether the card auto-closes after its first transaction. True for
+   * providers like Privacy.com that issue SINGLE_USE cards. When true,
+   * callers skip explicit cancelCard calls after checkout.
+   */
+  autoCancelAfterUse: boolean;
+  /**
+   * Whether the provider supports freezing (PAUSED) a card. When false,
+   * freezeCard throws UnsupportedProviderOperationError.
+   */
+  supportsFreeze: boolean;
+}
+
+export class UnsupportedProviderOperationError extends Error {
+  public readonly provider: PaymentProvider;
+  public readonly operation: string;
+
+  constructor(provider: PaymentProvider, operation: string) {
+    super(`Provider ${provider} does not support operation: ${operation}`);
+    this.name = 'UnsupportedProviderOperationError';
+    this.provider = provider;
+    this.operation = operation;
+  }
 }

--- a/src/orchestrator/intentService.ts
+++ b/src/orchestrator/intentService.ts
@@ -101,6 +101,17 @@ async function applyPostCheckoutCancelPolicy(intentId: string): Promise<void> {
   const { cancelPolicy, cardTtlMinutes, telegramChatId, paymentProvider } = intent.user;
   const provider = getPaymentProvider(paymentProvider);
 
+  // Providers that auto-close their cards after first use (e.g. Privacy.com
+  // SINGLE_USE) make cancelCard redundant. Explicit cancel/freeze calls still
+  // succeed but are no-ops at the provider level — skip them to avoid log noise.
+  if (provider.metadata.autoCancelAfterUse) {
+    log.info(
+      { intentId, provider: paymentProvider },
+      'Skipping post-checkout cancel — provider auto-closes cards after use',
+    );
+    return;
+  }
+
   if (cancelPolicy === 'ON_TRANSACTION') {
     // Cancellation is handled by the issuing_transaction.created Stripe webhook.
     // Fallback for stub/test flows where no real Stripe transaction fires:
@@ -116,6 +127,14 @@ async function applyPostCheckoutCancelPolicy(intentId: string): Promise<void> {
   } else if (cancelPolicy === 'AFTER_TTL' && cardTtlMinutes) {
     await enqueueCancelCard(intentId, cardTtlMinutes * 60 * 1000);
   } else if (cancelPolicy === 'MANUAL') {
+    // MANUAL needs freezeCard — skip for providers that don't support it.
+    if (!provider.metadata.supportsFreeze) {
+      log.warn(
+        { intentId, provider: paymentProvider },
+        'MANUAL cancel policy selected but provider does not support freeze — leaving card as-is',
+      );
+      return;
+    }
     await provider.freezeCard(intentId).catch((err) => {
       log.error({ intentId, err }, 'MANUAL card freeze failed');
     });

--- a/src/payments/providerFactory.ts
+++ b/src/payments/providerFactory.ts
@@ -28,6 +28,12 @@ export function getPaymentProvider(providerType: PaymentProvider): IPaymentProvi
         instance = new StripePaymentProvider();
         break;
       }
+      case PaymentProvider.PRIVACY_COM: {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { PrivacyComPaymentProvider } = require('./providers/privacy');
+        instance = new PrivacyComPaymentProvider();
+        break;
+      }
       default:
         throw new Error(`Unsupported payment provider: ${providerType}`);
     }

--- a/src/payments/providers/mock/mockProvider.ts
+++ b/src/payments/providers/mock/mockProvider.ts
@@ -11,7 +11,11 @@ type CallRecord = { method: string; args: unknown[]; timestamp: number };
 
 const METADATA: ProviderMetadata = {
   id: PaymentProvider.STRIPE,
+  displayName: 'Mock (Stripe-compatible)',
   currency: 'eur',
+  authorizationModel: 'per_transaction',
+  autoCancelAfterUse: false,
+  supportsFreeze: true,
 };
 
 export class MockPaymentProvider implements IPaymentProvider {

--- a/src/payments/providers/privacy/cardService.ts
+++ b/src/payments/providers/privacy/cardService.ts
@@ -1,0 +1,124 @@
+import { prisma } from '@/db/client';
+import {
+  VirtualCardData,
+  CardReveal,
+  CardAlreadyRevealedError,
+  IntentNotFoundError,
+  UnsupportedProviderOperationError,
+  PaymentProvider,
+} from '@/contracts';
+import { logger } from '@/config/logger';
+import { createCard, updateCard, PrivacyApiError } from './privacyClient';
+import { store, takeOnce } from './revealCache';
+
+const log = logger.child({ module: 'payments/privacy/cardService' });
+
+/**
+ * Issue a SINGLE_USE Privacy.com card for the given intent.
+ *
+ * Privacy.com has no idempotency-key header, so we dedupe client-side: if a
+ * VirtualCard row already exists for this intent, return it unchanged.
+ */
+export async function issueVirtualCard(intentId: string, amount: number): Promise<VirtualCardData> {
+  const intent = await prisma.purchaseIntent.findUnique({ where: { id: intentId } });
+  if (!intent) throw new IntentNotFoundError(intentId);
+
+  // Client-side idempotency: Privacy.com has no Idempotency-Key header.
+  const existing = await prisma.virtualCard.findUnique({ where: { intentId } });
+  if (existing) return existing as unknown as VirtualCardData;
+
+  let card;
+  try {
+    card = await createCard({
+      type: 'SINGLE_USE',
+      memo: (intent.subject ?? intent.query).slice(0, 50),
+      spend_limit: amount,
+      spend_limit_duration: 'TRANSACTION',
+      state: 'OPEN',
+    });
+  } catch (err) {
+    if (err instanceof PrivacyApiError) {
+      log.error({ intentId, status: err.status }, 'Privacy.com card creation failed');
+    }
+    throw err;
+  }
+
+  // Cache PAN/CVV in process memory for the subsequent revealCard call.
+  // Never persisted to the DB (PCI scope).
+  store(intentId, {
+    number: card.pan,
+    cvc: card.cvv,
+    expMonth: parseInt(card.exp_month, 10),
+    expYear: parseInt(card.exp_year, 10),
+    last4: card.last_four,
+  });
+
+  const virtualCard = await prisma.virtualCard.create({
+    data: {
+      intentId,
+      providerCardId: card.token,
+      last4: card.last_four,
+    },
+  });
+
+  return virtualCard as unknown as VirtualCardData;
+}
+
+export async function revealCard(intentId: string): Promise<CardReveal> {
+  const card = await prisma.virtualCard.findUnique({ where: { intentId } });
+  if (!card) throw new IntentNotFoundError(intentId);
+  if (card.revealedAt) throw new CardAlreadyRevealedError(intentId);
+
+  const reveal = takeOnce(intentId);
+  if (!reveal) {
+    // Cache miss: server restart, TTL expired, or the intent was issued on a
+    // different node. Privacy.com doesn't let us re-retrieve PAN server-side,
+    // so the card is effectively unreachable from this side.
+    throw new Error(
+      `Privacy.com card reveal cache miss for intent ${intentId} — card is no longer retrievable`,
+    );
+  }
+
+  await prisma.virtualCard.update({
+    where: { intentId },
+    data: { revealedAt: new Date() },
+  });
+
+  return reveal;
+}
+
+export async function freezeCard(_intentId: string): Promise<void> {
+  // Privacy.com's SINGLE_USE cards don't support pausing — the card either
+  // has unused spend and is OPEN, or has been used and is CLOSED.
+  throw new UnsupportedProviderOperationError(PaymentProvider.PRIVACY_COM, 'freezeCard');
+}
+
+/**
+ * Best-effort cancel. Privacy.com SINGLE_USE cards self-close after the first
+ * transaction; calling PATCH /cards/{token} {state: CLOSED} on an already-
+ * closed card returns an error that we swallow.
+ */
+export async function cancelCard(intentId: string): Promise<void> {
+  const card = await prisma.virtualCard.findUnique({ where: { intentId } });
+  if (!card) throw new IntentNotFoundError(intentId);
+  if (card.cancelledAt) return;
+
+  try {
+    await updateCard(card.providerCardId, { state: 'CLOSED' });
+  } catch (err) {
+    if (err instanceof PrivacyApiError) {
+      // Already closed (self-closed after use) — not an error from our side.
+      log.warn(
+        { intentId, status: err.status },
+        'Privacy.com card close failed — likely already closed',
+      );
+    } else {
+      throw err;
+    }
+  }
+
+  await prisma.virtualCard.update({
+    where: { intentId },
+    data: { cancelledAt: new Date() },
+  });
+}

--- a/src/payments/providers/privacy/index.ts
+++ b/src/payments/providers/privacy/index.ts
@@ -1,0 +1,54 @@
+import {
+  IPaymentProvider,
+  IssuingBalance,
+  VirtualCardData,
+  CardReveal,
+  ProviderMetadata,
+  PaymentProvider,
+} from '@/contracts';
+import { issueVirtualCard, revealCard, freezeCard, cancelCard } from './cardService';
+import { handlePrivacyEvent } from './webhookHandler';
+
+const METADATA: ProviderMetadata = {
+  id: PaymentProvider.PRIVACY_COM,
+  displayName: 'Privacy.com',
+  currency: 'usd',
+  authorizationModel: 'fire_and_forget',
+  autoCancelAfterUse: true,
+  supportsFreeze: false,
+};
+
+export class PrivacyComPaymentProvider implements IPaymentProvider {
+  readonly metadata = METADATA;
+
+  async issueCard(intentId: string, amount: number): Promise<VirtualCardData> {
+    return issueVirtualCard(intentId, amount);
+  }
+
+  async revealCard(intentId: string): Promise<CardReveal> {
+    return revealCard(intentId);
+  }
+
+  async freezeCard(intentId: string): Promise<void> {
+    return freezeCard(intentId);
+  }
+
+  async cancelCard(intentId: string): Promise<void> {
+    return cancelCard(intentId);
+  }
+
+  async handleWebhookEvent(
+    rawBody: Buffer | string,
+    signature: string,
+  ): Promise<Record<string, unknown>> {
+    return handlePrivacyEvent(rawBody, signature);
+  }
+
+  async getIssuingBalance(): Promise<IssuingBalance> {
+    // Privacy.com doesn't expose an issuing-balance concept — funding is
+    // attached to cards at creation time and pulled from the linked bank
+    // account on authorization. Return a sentinel high balance so the
+    // approval flow's balance guard always passes for Privacy users.
+    return { available: Number.MAX_SAFE_INTEGER, currency: this.metadata.currency };
+  }
+}

--- a/src/payments/providers/privacy/privacyClient.ts
+++ b/src/payments/providers/privacy/privacyClient.ts
@@ -1,0 +1,102 @@
+/**
+ * Thin HTTP wrapper around the Privacy.com API.
+ *
+ * Docs: https://developers.privacy.com — base URL `https://api.privacy.com/v1/`.
+ * Auth header is `Authorization: api-key <TOKEN>` (not Bearer).
+ *
+ * No sandbox is available (as of this writing), so this module is designed
+ * to be fully mockable in tests via `setPrivacyFetch()`. Production calls go
+ * through `globalThis.fetch`.
+ */
+import { env } from '@/config/env';
+
+export interface PrivacyCardCreateParams {
+  type: 'SINGLE_USE' | 'MERCHANT_LOCKED' | 'DIGITAL_WALLET' | 'UNLOCKED';
+  memo?: string;
+  spend_limit: number;
+  spend_limit_duration: 'TRANSACTION' | 'MONTHLY' | 'ANNUALLY' | 'FOREVER';
+  state: 'OPEN' | 'PAUSED';
+}
+
+export interface PrivacyCard {
+  token: string;
+  last_four: string;
+  pan: string;
+  cvv: string;
+  exp_month: string;
+  exp_year: string;
+  memo?: string;
+  type: string;
+  spend_limit: number;
+  spend_limit_duration: string;
+  state: 'OPEN' | 'PAUSED' | 'CLOSED' | 'PENDING_ACTIVATION' | 'PENDING_FULFILLMENT';
+  created: string;
+}
+
+export interface PrivacyCardUpdateParams {
+  state?: 'OPEN' | 'PAUSED' | 'CLOSED';
+}
+
+/**
+ * Minimal fetch-shaped type so tests can inject a mock. We only need
+ * the subset that our client actually uses.
+ */
+export type FetchLike = (
+  url: string,
+  init: { method: string; headers: Record<string, string>; body?: string },
+) => Promise<{ ok: boolean; status: number; text: () => Promise<string> }>;
+
+let _fetch: FetchLike | null = null;
+
+/** Test-only: override the HTTP implementation. Production uses `globalThis.fetch`. */
+export function setPrivacyFetch(fn: FetchLike | null): void {
+  _fetch = fn;
+}
+
+function getFetch(): FetchLike {
+  if (_fetch) return _fetch;
+  return globalThis.fetch as unknown as FetchLike;
+}
+
+export class PrivacyApiError extends Error {
+  public readonly status: number;
+  public readonly body: string;
+
+  constructor(status: number, body: string) {
+    super(`Privacy.com API error ${status}: ${body}`);
+    this.name = 'PrivacyApiError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+function headers(): Record<string, string> {
+  return {
+    Authorization: `api-key ${env.PRIVACY_API_KEY}`,
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  };
+}
+
+async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
+  const url = `${env.PRIVACY_API_BASE_URL}${path}`;
+  const res = await getFetch()(url, {
+    method,
+    headers: headers(),
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await res.text();
+  if (!res.ok) throw new PrivacyApiError(res.status, text);
+  return text ? (JSON.parse(text) as T) : (undefined as T);
+}
+
+export async function createCard(params: PrivacyCardCreateParams): Promise<PrivacyCard> {
+  return request<PrivacyCard>('POST', '/cards', params);
+}
+
+export async function updateCard(
+  cardToken: string,
+  params: PrivacyCardUpdateParams,
+): Promise<PrivacyCard> {
+  return request<PrivacyCard>('PATCH', `/cards/${encodeURIComponent(cardToken)}`, params);
+}

--- a/src/payments/providers/privacy/revealCache.ts
+++ b/src/payments/providers/privacy/revealCache.ts
@@ -1,0 +1,39 @@
+/**
+ * Module-local cache for PAN/CVV of Privacy.com cards.
+ *
+ * Why this exists: Privacy.com returns `pan` and `cvv` only on the create
+ * response — there's no server-side retrieval path. Our two-step flow
+ * (issueCard then, later, revealCard) requires us to hold those values
+ * somewhere between the two calls.
+ *
+ * The cache is intentionally in process memory only:
+ *  - never persisted to the DB (PCI scope)
+ *  - never serialized to logs
+ *  - entries expire after a short TTL or on first reveal (whichever first)
+ *
+ * Consequence: if the server restarts between issueCard and revealCard, the
+ * agent cannot retrieve the card — the intent must be expired and re-issued.
+ * This is acceptable for v0.1; a production deployment would want a
+ * PCI-scoped secret store (e.g. encrypted Redis entry with a KMS-wrapped key).
+ */
+import { CardReveal } from '@/contracts';
+
+const TTL_MS = 10 * 60 * 1000; // 10 minutes
+const entries = new Map<string, { reveal: CardReveal; expiresAt: number }>();
+
+export function store(intentId: string, reveal: CardReveal): void {
+  entries.set(intentId, { reveal, expiresAt: Date.now() + TTL_MS });
+}
+
+export function takeOnce(intentId: string): CardReveal | null {
+  const entry = entries.get(intentId);
+  if (!entry) return null;
+  entries.delete(intentId);
+  if (entry.expiresAt < Date.now()) return null;
+  return entry.reveal;
+}
+
+/** Test-only: clear all cached entries. */
+export function clearAll(): void {
+  entries.clear();
+}

--- a/src/payments/providers/privacy/webhookHandler.ts
+++ b/src/payments/providers/privacy/webhookHandler.ts
@@ -1,0 +1,83 @@
+/**
+ * Privacy.com webhook handler.
+ *
+ * ⚠️ The exact signature scheme is NOT clearly documented in Privacy's public
+ * API docs. This implementation uses HMAC-SHA256 over the raw request body,
+ * compared against a header configurable via PRIVACY_WEBHOOK_SIGNATURE_HEADER
+ * (default `x-privacy-signature`). Before going live, verify the scheme
+ * against the webhook config shown in the Privacy.com dashboard and adjust
+ * if needed.
+ *
+ * Privacy's delivery format appears to be the raw `Transaction` JSON object
+ * (not a Stripe-style `{type, data}` envelope), per the developer docs.
+ */
+import crypto from 'crypto';
+import { env } from '@/config/env';
+import { prisma } from '@/db/client';
+import { logger } from '@/config/logger';
+
+const log = logger.child({ module: 'payments/privacy/webhookHandler' });
+
+export interface PrivacyTransactionEvent {
+  token?: string;
+  card_token?: string;
+  amount?: number;
+  status?: string;
+  result?: string;
+  // Privacy's Transaction object has more fields; we only touch these for now.
+  [key: string]: unknown;
+}
+
+function verifySignature(rawBody: Buffer | string, signature: string): boolean {
+  if (!signature) return false;
+  const bodyBytes = typeof rawBody === 'string' ? Buffer.from(rawBody, 'utf8') : rawBody;
+  const expected = crypto
+    .createHmac('sha256', env.PRIVACY_WEBHOOK_SECRET)
+    .update(bodyBytes)
+    .digest('hex');
+  try {
+    return crypto.timingSafeEqual(Buffer.from(expected, 'hex'), Buffer.from(signature, 'hex'));
+  } catch {
+    return false;
+  }
+}
+
+export async function handlePrivacyEvent(
+  rawBody: Buffer | string,
+  signature: string,
+): Promise<Record<string, unknown>> {
+  if (!verifySignature(rawBody, signature)) {
+    throw new Error('Privacy.com webhook signature verification failed');
+  }
+
+  const payload = JSON.parse(
+    typeof rawBody === 'string' ? rawBody : rawBody.toString('utf8'),
+  ) as PrivacyTransactionEvent;
+
+  // Correlate back to our intent via the card_token we stored on the VirtualCard.
+  const cardToken = payload.card_token;
+  if (!cardToken) {
+    log.warn({ payload }, 'Privacy webhook missing card_token — skipping correlation');
+    return { received: true };
+  }
+
+  const virtualCard = await prisma.virtualCard.findUnique({
+    where: { providerCardId: cardToken },
+    select: { intentId: true },
+  });
+  if (!virtualCard) {
+    log.warn({ cardToken }, 'Privacy webhook for unknown card_token');
+    return { received: true };
+  }
+
+  await prisma.auditEvent.create({
+    data: {
+      intentId: virtualCard.intentId,
+      actor: 'privacy_com',
+      event: 'PRIVACY_TRANSACTION',
+      payload: payload as never,
+    },
+  });
+
+  return { received: true };
+}

--- a/src/payments/providers/stripe/index.ts
+++ b/src/payments/providers/stripe/index.ts
@@ -12,7 +12,11 @@ import { handleStripeEvent } from './webhookHandler';
 
 const METADATA: ProviderMetadata = {
   id: PaymentProvider.STRIPE,
+  displayName: 'Stripe Issuing',
   currency: 'eur',
+  authorizationModel: 'per_transaction',
+  autoCancelAfterUse: false,
+  supportsFreeze: true,
 };
 
 export class StripePaymentProvider implements IPaymentProvider {

--- a/src/payments/providers/stripe/reconciliationService.ts
+++ b/src/payments/providers/stripe/reconciliationService.ts
@@ -1,6 +1,12 @@
 import { getStripeClient } from './stripeClient';
 import { prisma } from '@/db/client';
+import { logger } from '@/config/logger';
 import type { ReconciliationReport } from '@/contracts';
+
+const log = logger.child({ module: 'payments/stripe/reconciliationService' });
+
+// Safety cap for stripe.issuing.transactions.list pagination.
+const MAX_TRANSACTIONS = 1000;
 
 export async function reconcileIntent(intentId: string): Promise<ReconciliationReport> {
   const pot = await prisma.pot.findUnique({ where: { intentId } });
@@ -15,24 +21,73 @@ export async function reconcileIntent(intentId: string): Promise<ReconciliationR
   };
 
   if (!card) {
-    return { intentId, internal, stripe: null, inSync: true, discrepancies: [] };
+    const discrepancies: string[] = [];
+    const moneyMoved =
+      pot !== null &&
+      (pot.settledAmount > 0 || pot.status === 'SETTLED' || pot.status === 'RETURNED');
+    if (moneyMoved) {
+      discrepancies.push(
+        `virtualCard missing for intent with pot status ${pot!.status} (settledAmount ${pot!.settledAmount})`,
+      );
+    }
+    return {
+      intentId,
+      internal,
+      stripe: null,
+      inSync: discrepancies.length === 0,
+      discrepancies,
+    };
   }
 
   const stripe = getStripeClient();
-  const stripeCard = await stripe.issuing.cards.retrieve(card.providerCardId);
-  const txList = await stripe.issuing.transactions.list({
-    card: card.providerCardId,
-    type: 'capture',
-  });
 
-  const totalCaptured = txList.data.reduce((sum, t) => sum + t.amount, 0);
+  let stripeCard;
+  let transactions;
+  try {
+    stripeCard = await stripe.issuing.cards.retrieve(card.providerCardId);
+    transactions = await stripe.issuing.transactions
+      .list({ card: card.providerCardId })
+      .autoPagingToArray({ limit: MAX_TRANSACTIONS });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error(
+      { intentId, providerCardId: card.providerCardId, err },
+      'Stripe API call failed during reconciliation',
+    );
+    return {
+      intentId,
+      internal,
+      stripe: null,
+      inSync: false,
+      discrepancies: [`stripe API error: ${message}`],
+    };
+  }
+
+  // Net captured: Stripe Issuing captures are negative; refunds are positive.
+  let totalCaptured = 0;
+  for (const t of transactions) {
+    const abs = Math.abs(t.amount);
+    if (t.type === 'refund') {
+      totalCaptured -= abs;
+    } else {
+      totalCaptured += abs;
+    }
+  }
+
   const stripeReport = {
     cardStatus: stripeCard.status,
-    transactions: txList.data.map((t) => ({ id: t.id, amount: t.amount, type: t.type })),
+    transactions: transactions.map((t) => ({ id: t.id, amount: t.amount, type: t.type })),
     totalCaptured,
   };
 
   const discrepancies: string[] = [];
+
+  if (transactions.length >= MAX_TRANSACTIONS) {
+    discrepancies.push(
+      `stripe transactions truncated at ${MAX_TRANSACTIONS} — totalCaptured may be incomplete`,
+    );
+  }
+
   if (pot !== null && pot.settledAmount !== totalCaptured) {
     discrepancies.push(`settledAmount ${pot.settledAmount} != stripe captured ${totalCaptured}`);
   }

--- a/src/telegram/callbackHandler.ts
+++ b/src/telegram/callbackHandler.ts
@@ -1,4 +1,5 @@
 import type { Update } from 'grammy/types';
+import { InlineKeyboard } from 'grammy';
 import { prisma } from '@/db/client';
 import { ApprovalDecisionType, IntentStatus, InsufficientIssuingBalanceError } from '@/contracts';
 import { recordDecision } from '@/approval/approvalService';
@@ -67,13 +68,53 @@ export async function handleTelegramCallback(update: Update): Promise<void> {
       return;
     }
 
-    // link_confirm: advance session to awaiting_email
-    await setSignupSession(fromId, { ...session, step: 'awaiting_email' });
+    // link_confirm: advance session to provider-choice step
+    await setSignupSession(fromId, { ...session, step: 'awaiting_provider' });
+    const providerKeyboard = new InlineKeyboard()
+      .text('Stripe (EUR)', 'signup_provider:STRIPE')
+      .text('Privacy.com (USD)', 'signup_provider:PRIVACY_COM');
     await editMessage(
       bot,
       chatId,
       messageId,
-      `✅ Confirmed! What email address should we use for your account?`,
+      `✅ Confirmed!\n\n` +
+        `<b>Choose a payment provider:</b>\n\n` +
+        `<b>Stripe (EUR)</b> — per-transaction approval. The backend approves or declines every charge in real time, so the card can be used repeatedly within your budget and any mismatched merchant or category is stopped at authorisation.\n\n` +
+        `<b>Privacy.com (USD)</b> — "fire and forget". The card is issued as single-use with a hard spend cap, and closes itself after one transaction. There is no per-transaction approval step, so all limits are baked into the card at issuance.\n\n` +
+        `<i>Locked at signup — see issue #128 to allow switching later.</i>`,
+      providerKeyboard,
+    );
+    return;
+  }
+
+  // ── Provider-choice callback ──────────────────────────────────────────────────
+  if (action === 'signup_provider') {
+    const session = await getSignupSession(fromId);
+    if (!session || session.step !== 'awaiting_provider') {
+      await editMessage(
+        bot,
+        chatId,
+        messageId,
+        '⚠️ Session expired or not found. Please start again with /start <code>.',
+      );
+      return;
+    }
+
+    const chosen = payload as 'STRIPE' | 'PRIVACY_COM';
+    if (chosen !== 'STRIPE' && chosen !== 'PRIVACY_COM') return;
+
+    await setSignupSession(fromId, {
+      ...session,
+      step: 'awaiting_email',
+      paymentProvider: chosen,
+    });
+    const currency = chosen === 'STRIPE' ? 'EUR' : 'USD';
+    await editMessage(
+      bot,
+      chatId,
+      messageId,
+      `✅ Selected <b>${chosen === 'STRIPE' ? 'Stripe' : 'Privacy.com'} (${currency})</b>.\n\n` +
+        `What email address should we use for your account?`,
     );
     return;
   }
@@ -194,12 +235,13 @@ async function editMessage(
   chatId: number | string | undefined,
   messageId: number | undefined,
   text: string,
+  keyboard?: InlineKeyboard,
 ): Promise<void> {
   if (!chatId || !messageId) return;
   await bot.api
     .editMessageText(chatId, messageId, text, {
       parse_mode: 'HTML',
-      reply_markup: undefined,
+      reply_markup: keyboard,
     })
     .catch(() => {});
 }

--- a/src/telegram/sessionStore.ts
+++ b/src/telegram/sessionStore.ts
@@ -1,12 +1,14 @@
 import { getRedisClient } from '@/config/redis';
+import { PaymentProvider } from '@/contracts';
 
 const KEY_PREFIX = 'telegram_signup:';
 const DEFAULT_TTL_SECONDS = 600; // 10 minutes
 
 export interface SignupSession {
-  step: 'awaiting_confirmation' | 'awaiting_email';
+  step: 'awaiting_confirmation' | 'awaiting_provider' | 'awaiting_email';
   agentId: string;
   pairingCode: string;
+  paymentProvider?: PaymentProvider;
 }
 
 export async function getSignupSession(chatId: number | string): Promise<SignupSession | null> {

--- a/src/telegram/signupHandler.ts
+++ b/src/telegram/signupHandler.ts
@@ -119,7 +119,21 @@ export async function handleTelegramMessage(update: Update): Promise<void> {
     return;
   }
 
+  if (session.step === 'awaiting_provider') {
+    await bot.api.sendMessage(chatId, 'Please pick a payment provider using the buttons above.');
+    return;
+  }
+
   // step === 'awaiting_email'
+  if (!session.paymentProvider) {
+    // Defensive: email step reached without a provider choice. Reset.
+    await clearSignupSession(chatId);
+    await bot.api.sendMessage(
+      chatId,
+      '⚠️ Session is missing a provider choice. Please start again with /start <code>.',
+    );
+    return;
+  }
   const email = text.toLowerCase();
 
   if (!isValidEmail(email)) {
@@ -140,15 +154,18 @@ export async function handleTelegramMessage(update: Update): Promise<void> {
         });
       }
 
+      // 1_000_000 smallest units = 10,000 of the provider's currency
+      // (10,000 EUR for Stripe; 10,000 USD for Privacy.com).
       const user = await tx.user.create({
         data: {
           email,
           telegramChatId: chatId.toString(),
           agentId: session.agentId,
-          mainBalance: 1_000_000, // 10 000 EUR in cents
+          mainBalance: 1_000_000,
           maxBudgetPerIntent: 50000,
           apiKeyHash,
           apiKeyPrefix: rawKey.slice(0, 16),
+          paymentProvider: session.paymentProvider,
         },
       });
 

--- a/tests/integration/e2e/onboarding.test.ts
+++ b/tests/integration/e2e/onboarding.test.ts
@@ -336,6 +336,25 @@ testSuite('OpenClaw onboarding + first purchase intent (real DB + Redis)', () =>
       },
     });
     await new Promise((r) => setTimeout(r, 200));
+    // Same as the happy-path test: after confirm the session is awaiting_provider.
+    // Without this callback the email step never completes linking, claimedByUserId
+    // stays null, and a subsequent /register renewal hits the per-agent cooldown
+    // (429) instead of the expected 409.
+    await app.inject({
+      method: 'POST',
+      url: '/v1/webhooks/telegram',
+      headers: { 'x-telegram-bot-api-secret-token': TELEGRAM_SECRET },
+      payload: {
+        update_id: 20016,
+        callback_query: {
+          id: 'cb-provider-2',
+          data: 'signup_provider:STRIPE',
+          from: { id: chatId },
+          message: { message_id: 1, chat: { id: chatId } },
+        },
+      },
+    });
+    await new Promise((r) => setTimeout(r, 200));
     await app.inject({
       method: 'POST',
       url: '/v1/webhooks/telegram',

--- a/tests/integration/e2e/onboarding.test.ts
+++ b/tests/integration/e2e/onboarding.test.ts
@@ -150,7 +150,33 @@ testSuite('OpenClaw onboarding + first purchase intent (real DB + Redis)', () =>
     expect(confirmRes.statusCode).toBe(200);
     await new Promise((r) => setTimeout(r, 100));
 
-    // Bot should have edited the message asking for email
+    // After confirm, the bot edits the message to show the provider-choice keyboard.
+    expect(mockEditMessageText).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.stringContaining('payment provider'),
+      expect.any(Object),
+    );
+
+    // Step 3c: User taps "Stripe (EUR)" — callback query with signup_provider:STRIPE
+    const providerRes = await app.inject({
+      method: 'POST',
+      url: '/v1/webhooks/telegram',
+      headers: { 'x-telegram-bot-api-secret-token': TELEGRAM_SECRET },
+      payload: {
+        update_id: 10016,
+        callback_query: {
+          id: 'cb-provider-1',
+          data: 'signup_provider:STRIPE',
+          from: { id: chatId },
+          message: { message_id: 1, chat: { id: chatId } },
+        },
+      },
+    });
+    expect(providerRes.statusCode).toBe(200);
+    await new Promise((r) => setTimeout(r, 100));
+
+    // After provider choice, bot should ask for the email
     expect(mockEditMessageText).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),

--- a/tests/integration/stripe/reconciliation.test.ts
+++ b/tests/integration/stripe/reconciliation.test.ts
@@ -8,6 +8,7 @@
  *   npm run test:integration -- --testPathPattern=reconciliation
  */
 
+import crypto from 'crypto';
 import Stripe from 'stripe';
 import { prisma } from '@/db/client';
 import { reconcileIntent } from '@/payments/providers/stripe/reconciliationService';
@@ -25,7 +26,6 @@ describeIfStripe('Reconciliation integration', () => {
   beforeAll(async () => {
     stripe = new Stripe(STRIPE_KEY!, { apiVersion: '2024-06-20' as Stripe.LatestApiVersion });
 
-    // Create minimal DB records
     const user = await prisma.user.create({
       data: {
         email: `recon-test-${Date.now()}@example.com`,
@@ -40,13 +40,13 @@ describeIfStripe('Reconciliation integration', () => {
         userId,
         query: 'reconciliation test product',
         maxBudget: 5000,
-        currency: 'gbp',
+        currency: 'eur',
         status: 'DONE',
+        idempotencyKey: `recon-test-${crypto.randomUUID()}`,
       },
     });
     intentId = intent.id;
 
-    // Create Stripe cardholder and card
     const cardholder = await stripe.issuing.cardholders.create({
       name: 'Recon Test',
       email: `recon-stripe-${Date.now()}@example.com`,
@@ -74,39 +74,42 @@ describeIfStripe('Reconciliation integration', () => {
     });
     cardId = card.id;
 
-    // Write VirtualCard to DB
     await prisma.virtualCard.create({
       data: { intentId, providerCardId: cardId, last4: card.last4 },
     });
 
-    // Simulate a capture
-    const auth = await stripe.testHelpers.issuing.authorizations.create({
+    await stripe.testHelpers.issuing.transactions.createForceCapture({
       card: cardId,
       amount: 3500,
       currency: 'eur',
       merchant_data: { name: 'Test Merchant' },
     });
-    await stripe.testHelpers.issuing.authorizations.capture(auth.id);
 
-    // Cancel the card (mirrors what the system does post-checkout)
     await stripe.issuing.cards.update(cardId, { status: 'canceled' });
 
-    // Write matching ledger records
     await prisma.pot.create({
-      data: { intentId, reservedAmount: 5000, settledAmount: 3500, status: 'SETTLED' },
+      data: {
+        userId,
+        intentId,
+        reservedAmount: 5000,
+        settledAmount: 3500,
+        status: 'SETTLED',
+      },
     });
     await prisma.ledgerEntry.create({
-      data: { intentId, type: 'RESERVE', amount: 5000 },
+      data: { userId, intentId, type: 'RESERVE', amount: 5000 },
     });
     await prisma.ledgerEntry.create({
-      data: { intentId, type: 'SETTLE', amount: 3500 },
+      data: { userId, intentId, type: 'SETTLE', amount: 3500 },
     });
   }, 60_000);
 
   afterAll(async () => {
-    // Clean up DB records (cascade delete via purchaseIntent)
-    await prisma.purchaseIntent.delete({ where: { id: intentId } }).catch(() => {});
-    await prisma.user.delete({ where: { id: userId } }).catch(() => {});
+    await prisma.ledgerEntry.deleteMany({ where: { intentId } }).catch(() => {});
+    await prisma.pot.deleteMany({ where: { intentId } }).catch(() => {});
+    await prisma.virtualCard.deleteMany({ where: { intentId } }).catch(() => {});
+    await prisma.purchaseIntent.deleteMany({ where: { id: intentId } }).catch(() => {});
+    await prisma.user.deleteMany({ where: { id: userId } }).catch(() => {});
     await prisma.$disconnect();
   });
 
@@ -120,7 +123,6 @@ describeIfStripe('Reconciliation integration', () => {
   });
 
   it('returns inSync:false with discrepancy when settledAmount is wrong', async () => {
-    // Corrupt the pot
     await prisma.pot.update({
       where: { intentId },
       data: { settledAmount: 9999 },
@@ -131,7 +133,6 @@ describeIfStripe('Reconciliation integration', () => {
     expect(report.inSync).toBe(false);
     expect(report.discrepancies.some((d) => d.includes('9999'))).toBe(true);
 
-    // Restore
     await prisma.pot.update({
       where: { intentId },
       data: { settledAmount: 3500 },

--- a/tests/unit/payments/mockProvider.test.ts
+++ b/tests/unit/payments/mockProvider.test.ts
@@ -10,9 +10,12 @@ describe('MockPaymentProvider', () => {
 
   describe('metadata', () => {
     it('exposes provider metadata with Stripe-compatible defaults', () => {
-      expect(provider.metadata).toEqual({
+      expect(provider.metadata).toMatchObject({
         id: PaymentProvider.STRIPE,
         currency: 'eur',
+        authorizationModel: 'per_transaction',
+        autoCancelAfterUse: false,
+        supportsFreeze: true,
       });
     });
   });

--- a/tests/unit/payments/privacyProvider.test.ts
+++ b/tests/unit/payments/privacyProvider.test.ts
@@ -1,0 +1,291 @@
+// Mock the Privacy HTTP client + DB before importing the provider.
+const mockCreateCard = jest.fn();
+const mockUpdateCard = jest.fn();
+jest.mock('@/payments/providers/privacy/privacyClient', () => {
+  const actual = jest.requireActual('@/payments/providers/privacy/privacyClient');
+  return {
+    ...actual,
+    createCard: mockCreateCard,
+    updateCard: mockUpdateCard,
+  };
+});
+
+jest.mock('@/db/client', () => ({
+  prisma: {
+    purchaseIntent: { findUnique: jest.fn() },
+    virtualCard: { create: jest.fn(), findUnique: jest.fn(), update: jest.fn() },
+  },
+}));
+
+import { PrivacyComPaymentProvider } from '@/payments/providers/privacy';
+import { clearAll as clearRevealCache } from '@/payments/providers/privacy/revealCache';
+import { PrivacyApiError } from '@/payments/providers/privacy/privacyClient';
+import { prisma } from '@/db/client';
+import {
+  CardAlreadyRevealedError,
+  IntentNotFoundError,
+  PaymentProvider,
+  UnsupportedProviderOperationError,
+} from '@/contracts';
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+
+describe('PrivacyComPaymentProvider', () => {
+  let provider: PrivacyComPaymentProvider;
+
+  beforeEach(() => {
+    provider = new PrivacyComPaymentProvider();
+    jest.clearAllMocks();
+    clearRevealCache();
+  });
+
+  describe('metadata', () => {
+    it('declares fire-and-forget model, auto-close, no freeze, USD', () => {
+      expect(provider.metadata).toEqual({
+        id: PaymentProvider.PRIVACY_COM,
+        displayName: 'Privacy.com',
+        currency: 'usd',
+        authorizationModel: 'fire_and_forget',
+        autoCancelAfterUse: true,
+        supportsFreeze: false,
+      });
+    });
+  });
+
+  describe('issueCard', () => {
+    it('creates a SINGLE_USE card with spend_limit_duration TRANSACTION', async () => {
+      (mockPrisma.purchaseIntent.findUnique as jest.Mock).mockResolvedValue({
+        id: 'intent-1',
+        query: 'headphones',
+        subject: null,
+      });
+      (mockPrisma.virtualCard.findUnique as jest.Mock).mockResolvedValue(null);
+      mockCreateCard.mockResolvedValue({
+        token: 'priv_card_abc',
+        last_four: '1234',
+        pan: '4111111111111234',
+        cvv: '999',
+        exp_month: '12',
+        exp_year: '2030',
+        type: 'SINGLE_USE',
+        spend_limit: 10000,
+        spend_limit_duration: 'TRANSACTION',
+        state: 'OPEN',
+        created: '2026-04-18T00:00:00Z',
+      });
+      (mockPrisma.virtualCard.create as jest.Mock).mockResolvedValue({
+        id: 'vc-1',
+        intentId: 'intent-1',
+        providerCardId: 'priv_card_abc',
+        last4: '1234',
+      });
+
+      const result = await provider.issueCard('intent-1', 10000);
+
+      expect(mockCreateCard).toHaveBeenCalledWith({
+        type: 'SINGLE_USE',
+        memo: 'headphones',
+        spend_limit: 10000,
+        spend_limit_duration: 'TRANSACTION',
+        state: 'OPEN',
+      });
+      expect(result.providerCardId).toBe('priv_card_abc');
+      expect(result.last4).toBe('1234');
+    });
+
+    it('never stores PAN or CVV in the DB', async () => {
+      (mockPrisma.purchaseIntent.findUnique as jest.Mock).mockResolvedValue({
+        id: 'intent-1',
+        query: 'x',
+        subject: null,
+      });
+      (mockPrisma.virtualCard.findUnique as jest.Mock).mockResolvedValue(null);
+      mockCreateCard.mockResolvedValue({
+        token: 't',
+        last_four: '5678',
+        pan: '4111111111115678',
+        cvv: '123',
+        exp_month: '06',
+        exp_year: '2031',
+        type: 'SINGLE_USE',
+        spend_limit: 5000,
+        spend_limit_duration: 'TRANSACTION',
+        state: 'OPEN',
+        created: '',
+      });
+      (mockPrisma.virtualCard.create as jest.Mock).mockResolvedValue({});
+
+      await provider.issueCard('intent-1', 5000);
+
+      const createArgs = (mockPrisma.virtualCard.create as jest.Mock).mock.calls[0][0];
+      expect(createArgs.data).not.toHaveProperty('pan');
+      expect(createArgs.data).not.toHaveProperty('cvv');
+      expect(createArgs.data).not.toHaveProperty('number');
+      expect(createArgs.data).not.toHaveProperty('cvc');
+    });
+
+    it('dedupes: returns the existing VirtualCard instead of re-issuing', async () => {
+      const existing = {
+        id: 'vc-existing',
+        intentId: 'intent-1',
+        providerCardId: 'priv_existing',
+        last4: '0000',
+      };
+      (mockPrisma.purchaseIntent.findUnique as jest.Mock).mockResolvedValue({ id: 'intent-1' });
+      (mockPrisma.virtualCard.findUnique as jest.Mock).mockResolvedValue(existing);
+
+      const result = await provider.issueCard('intent-1', 5000);
+
+      expect(mockCreateCard).not.toHaveBeenCalled();
+      expect(result).toBe(existing);
+    });
+
+    it('throws IntentNotFoundError for missing intent', async () => {
+      (mockPrisma.purchaseIntent.findUnique as jest.Mock).mockResolvedValue(null);
+
+      await expect(provider.issueCard('missing', 5000)).rejects.toThrow(IntentNotFoundError);
+    });
+  });
+
+  describe('revealCard', () => {
+    it('returns PAN/CVV cached at issuance and purges the entry', async () => {
+      // First, issue to populate the cache
+      (mockPrisma.purchaseIntent.findUnique as jest.Mock).mockResolvedValue({
+        id: 'intent-r',
+        query: 'x',
+        subject: null,
+      });
+      (mockPrisma.virtualCard.findUnique as jest.Mock).mockResolvedValueOnce(null);
+      mockCreateCard.mockResolvedValue({
+        token: 'tok',
+        last_four: '9999',
+        pan: '4111111111119999',
+        cvv: '321',
+        exp_month: '01',
+        exp_year: '2029',
+        type: 'SINGLE_USE',
+        spend_limit: 1000,
+        spend_limit_duration: 'TRANSACTION',
+        state: 'OPEN',
+        created: '',
+      });
+      (mockPrisma.virtualCard.create as jest.Mock).mockResolvedValue({});
+      await provider.issueCard('intent-r', 1000);
+
+      // Now reveal
+      (mockPrisma.virtualCard.findUnique as jest.Mock).mockResolvedValueOnce({
+        intentId: 'intent-r',
+        providerCardId: 'tok',
+        revealedAt: null,
+      });
+      (mockPrisma.virtualCard.update as jest.Mock).mockResolvedValue({});
+
+      const reveal = await provider.revealCard('intent-r');
+
+      expect(reveal).toEqual({
+        number: '4111111111119999',
+        cvc: '321',
+        expMonth: 1,
+        expYear: 2029,
+        last4: '9999',
+      });
+
+      // Second reveal should miss the cache and throw
+      (mockPrisma.virtualCard.findUnique as jest.Mock).mockResolvedValueOnce({
+        intentId: 'intent-r',
+        providerCardId: 'tok',
+        revealedAt: null, // pretend DB hasn't recorded revealedAt yet to isolate cache behavior
+      });
+      await expect(provider.revealCard('intent-r')).rejects.toThrow(/cache miss/);
+    });
+
+    it('throws CardAlreadyRevealedError when the DB row has revealedAt set', async () => {
+      (mockPrisma.virtualCard.findUnique as jest.Mock).mockResolvedValue({
+        intentId: 'i',
+        providerCardId: 't',
+        revealedAt: new Date(),
+      });
+
+      await expect(provider.revealCard('i')).rejects.toThrow(CardAlreadyRevealedError);
+    });
+
+    it('throws IntentNotFoundError when the card is missing', async () => {
+      (mockPrisma.virtualCard.findUnique as jest.Mock).mockResolvedValue(null);
+
+      await expect(provider.revealCard('missing')).rejects.toThrow(IntentNotFoundError);
+    });
+  });
+
+  describe('freezeCard', () => {
+    it('throws UnsupportedProviderOperationError', async () => {
+      await expect(provider.freezeCard('intent-1')).rejects.toThrow(
+        UnsupportedProviderOperationError,
+      );
+    });
+  });
+
+  describe('cancelCard', () => {
+    it('PATCHes the card to CLOSED and records cancelledAt', async () => {
+      (mockPrisma.virtualCard.findUnique as jest.Mock).mockResolvedValue({
+        intentId: 'intent-c',
+        providerCardId: 'tok',
+        cancelledAt: null,
+      });
+      mockUpdateCard.mockResolvedValue({ token: 'tok', state: 'CLOSED' });
+      (mockPrisma.virtualCard.update as jest.Mock).mockResolvedValue({});
+
+      await provider.cancelCard('intent-c');
+
+      expect(mockUpdateCard).toHaveBeenCalledWith('tok', { state: 'CLOSED' });
+      expect(mockPrisma.virtualCard.update).toHaveBeenCalledWith({
+        where: { intentId: 'intent-c' },
+        data: expect.objectContaining({ cancelledAt: expect.any(Date) }),
+      });
+    });
+
+    it('swallows PrivacyApiError (already closed) but still records cancelledAt', async () => {
+      (mockPrisma.virtualCard.findUnique as jest.Mock).mockResolvedValue({
+        intentId: 'intent-c',
+        providerCardId: 'tok',
+        cancelledAt: null,
+      });
+      mockUpdateCard.mockRejectedValue(new PrivacyApiError(400, 'already closed'));
+      (mockPrisma.virtualCard.update as jest.Mock).mockResolvedValue({});
+
+      await expect(provider.cancelCard('intent-c')).resolves.toBeUndefined();
+      expect(mockPrisma.virtualCard.update).toHaveBeenCalled();
+    });
+
+    it('returns early when already cancelled in our DB', async () => {
+      (mockPrisma.virtualCard.findUnique as jest.Mock).mockResolvedValue({
+        intentId: 'intent-c',
+        providerCardId: 'tok',
+        cancelledAt: new Date(),
+      });
+
+      await provider.cancelCard('intent-c');
+
+      expect(mockUpdateCard).not.toHaveBeenCalled();
+    });
+
+    it('rethrows non-PrivacyApiError failures', async () => {
+      (mockPrisma.virtualCard.findUnique as jest.Mock).mockResolvedValue({
+        intentId: 'intent-c',
+        providerCardId: 'tok',
+        cancelledAt: null,
+      });
+      const boom = new Error('network blown');
+      mockUpdateCard.mockRejectedValue(boom);
+
+      await expect(provider.cancelCard('intent-c')).rejects.toBe(boom);
+    });
+  });
+
+  describe('getIssuingBalance', () => {
+    it('returns a sentinel high balance in USD (no issuing-balance concept)', async () => {
+      const balance = await provider.getIssuingBalance();
+      expect(balance.currency).toBe('usd');
+      expect(balance.available).toBe(Number.MAX_SAFE_INTEGER);
+    });
+  });
+});

--- a/tests/unit/payments/privacyWebhook.test.ts
+++ b/tests/unit/payments/privacyWebhook.test.ts
@@ -1,0 +1,82 @@
+import crypto from 'crypto';
+
+jest.mock('@/config/env', () => ({
+  env: {
+    PRIVACY_WEBHOOK_SECRET: 'test_secret',
+    PRIVACY_WEBHOOK_SIGNATURE_HEADER: 'x-privacy-signature',
+  },
+}));
+
+jest.mock('@/db/client', () => ({
+  prisma: {
+    virtualCard: { findUnique: jest.fn() },
+    auditEvent: { create: jest.fn() },
+  },
+}));
+
+import { handlePrivacyEvent } from '@/payments/providers/privacy/webhookHandler';
+import { prisma } from '@/db/client';
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+
+function sign(body: string, secret = 'test_secret'): string {
+  return crypto.createHmac('sha256', secret).update(body).digest('hex');
+}
+
+describe('handlePrivacyEvent', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('rejects invalid signature', async () => {
+    const body = JSON.stringify({ card_token: 'tok', amount: 100 });
+
+    await expect(handlePrivacyEvent(body, 'not-the-right-sig')).rejects.toThrow(
+      /signature verification failed/,
+    );
+  });
+
+  it('accepts a valid HMAC-SHA256 signature and logs an audit event', async () => {
+    const body = JSON.stringify({ card_token: 'tok-1', amount: 500, result: 'APPROVED' });
+    const sig = sign(body);
+    (mockPrisma.virtualCard.findUnique as jest.Mock).mockResolvedValue({ intentId: 'intent-1' });
+    (mockPrisma.auditEvent.create as jest.Mock).mockResolvedValue({});
+
+    const res = await handlePrivacyEvent(body, sig);
+
+    expect(res).toEqual({ received: true });
+    expect(mockPrisma.virtualCard.findUnique).toHaveBeenCalledWith({
+      where: { providerCardId: 'tok-1' },
+      select: { intentId: true },
+    });
+    expect(mockPrisma.auditEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          intentId: 'intent-1',
+          actor: 'privacy_com',
+          event: 'PRIVACY_TRANSACTION',
+        }),
+      }),
+    );
+  });
+
+  it('returns {received: true} but skips correlation when card_token is missing', async () => {
+    const body = JSON.stringify({ amount: 500 });
+    const sig = sign(body);
+
+    const res = await handlePrivacyEvent(body, sig);
+
+    expect(res).toEqual({ received: true });
+    expect(mockPrisma.virtualCard.findUnique).not.toHaveBeenCalled();
+    expect(mockPrisma.auditEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('returns {received: true} when the card_token has no matching VirtualCard', async () => {
+    const body = JSON.stringify({ card_token: 'unknown', amount: 500 });
+    const sig = sign(body);
+    (mockPrisma.virtualCard.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const res = await handlePrivacyEvent(body, sig);
+
+    expect(res).toEqual({ received: true });
+    expect(mockPrisma.auditEvent.create).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/payments/reconciliationService.test.ts
+++ b/tests/unit/payments/reconciliationService.test.ts
@@ -1,15 +1,15 @@
-// Mock stripe before imports
+const mockAutoPagingToArray = jest.fn();
+const mockTransactionsList = jest.fn(() => ({ autoPagingToArray: mockAutoPagingToArray }));
 const mockStripe = {
   issuing: {
     cards: { retrieve: jest.fn() },
-    transactions: { list: jest.fn() },
+    transactions: { list: mockTransactionsList },
   },
 };
 jest.mock('@/payments/providers/stripe/stripeClient', () => ({
   getStripeClient: () => mockStripe,
 }));
 
-// Mock prisma before imports
 const mockPot = jest.fn();
 const mockLedgerEntries = jest.fn();
 const mockVirtualCard = jest.fn();
@@ -21,87 +21,218 @@ jest.mock('@/db/client', () => ({
   },
 }));
 
+const mockChildLogger = {
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+};
+jest.mock('@/config/logger', () => ({
+  logger: { child: jest.fn(() => mockChildLogger) },
+}));
+
 import { reconcileIntent } from '@/payments/providers/stripe/reconciliationService';
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockChildLogger.error.mockClear();
 });
 
-describe('reconcileIntent', () => {
-  it('returns inSync:true when settledAmount matches stripe captured and card is canceled', async () => {
+describe('reconcileIntent — capture amount sign handling (issue #88)', () => {
+  it('treats Stripe-style negative capture amounts as positive captured totals', async () => {
     mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 3500, status: 'SETTLED' });
-    mockLedgerEntries.mockResolvedValue([
-      { type: 'RESERVE', amount: 5000 },
-      { type: 'SETTLE', amount: 3500 },
-    ]);
-    mockVirtualCard.mockResolvedValue({ intentId: 'intent-1', providerCardId: 'ic_123' });
+    mockLedgerEntries.mockResolvedValue([{ type: 'SETTLE', amount: 3500 }]);
+    mockVirtualCard.mockResolvedValue({ intentId: 'intent-1', providerCardId: 'ic_neg' });
     mockStripe.issuing.cards.retrieve.mockResolvedValue({ status: 'canceled' });
-    mockStripe.issuing.transactions.list.mockResolvedValue({
-      data: [{ id: 'itxn_1', amount: 3500, type: 'capture' }],
-    });
+    mockAutoPagingToArray.mockResolvedValue([{ id: 'itxn_1', amount: -3500, type: 'capture' }]);
 
     const report = await reconcileIntent('intent-1');
 
+    expect(report.stripe?.totalCaptured).toBe(3500);
     expect(report.inSync).toBe(true);
     expect(report.discrepancies).toHaveLength(0);
-    expect(report.stripe?.totalCaptured).toBe(3500);
   });
 
-  it('returns inSync:false with discrepancy when settledAmount differs from stripe captured', async () => {
+  it('flags a real settlement mismatch', async () => {
     mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 3500, status: 'SETTLED' });
     mockLedgerEntries.mockResolvedValue([]);
-    mockVirtualCard.mockResolvedValue({ intentId: 'intent-2', providerCardId: 'ic_456' });
+    mockVirtualCard.mockResolvedValue({ intentId: 'intent-2', providerCardId: 'ic_mis' });
     mockStripe.issuing.cards.retrieve.mockResolvedValue({ status: 'canceled' });
-    mockStripe.issuing.transactions.list.mockResolvedValue({
-      data: [{ id: 'itxn_2', amount: 4000, type: 'capture' }],
-    });
+    mockAutoPagingToArray.mockResolvedValue([{ id: 'itxn_2', amount: -4000, type: 'capture' }]);
 
     const report = await reconcileIntent('intent-2');
 
     expect(report.inSync).toBe(false);
     expect(report.discrepancies).toContain('settledAmount 3500 != stripe captured 4000');
   });
+});
 
-  it('returns inSync:false with discrepancy when pot is SETTLED but card is still active', async () => {
-    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 3500, status: 'SETTLED' });
-    mockLedgerEntries.mockResolvedValue([]);
-    mockVirtualCard.mockResolvedValue({ intentId: 'intent-3', providerCardId: 'ic_789' });
-    mockStripe.issuing.cards.retrieve.mockResolvedValue({ status: 'active' });
-    mockStripe.issuing.transactions.list.mockResolvedValue({
-      data: [{ id: 'itxn_3', amount: 3500, type: 'capture' }],
-    });
+describe('reconcileIntent — refunds (issue #88)', () => {
+  it('subtracts refund transactions from the net captured total', async () => {
+    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 3000, status: 'SETTLED' });
+    mockLedgerEntries.mockResolvedValue([{ type: 'SETTLE', amount: 3000 }]);
+    mockVirtualCard.mockResolvedValue({ intentId: 'intent-3', providerCardId: 'ic_refund' });
+    mockStripe.issuing.cards.retrieve.mockResolvedValue({ status: 'canceled' });
+    mockAutoPagingToArray.mockResolvedValue([
+      { id: 'itxn_cap', amount: -4000, type: 'capture' },
+      { id: 'itxn_ref', amount: 1000, type: 'refund' },
+    ]);
 
     const report = await reconcileIntent('intent-3');
+
+    expect(report.stripe?.totalCaptured).toBe(3000);
+    expect(report.inSync).toBe(true);
+  });
+});
+
+describe('reconcileIntent — Stripe API error handling (issue #88)', () => {
+  it('returns a discrepancy report instead of throwing when cards.retrieve fails', async () => {
+    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 3500, status: 'SETTLED' });
+    mockLedgerEntries.mockResolvedValue([]);
+    mockVirtualCard.mockResolvedValue({ intentId: 'intent-err', providerCardId: 'ic_404' });
+    mockStripe.issuing.cards.retrieve.mockRejectedValue(new Error('No such card: ic_404'));
+
+    const report = await reconcileIntent('intent-err');
+
+    expect(report.inSync).toBe(false);
+    expect(report.stripe).toBeNull();
+    expect(report.discrepancies[0]).toContain('stripe API error');
+    expect(mockChildLogger.error).toHaveBeenCalled();
+  });
+
+  it('returns a discrepancy report when transactions.list paging fails', async () => {
+    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 3500, status: 'SETTLED' });
+    mockLedgerEntries.mockResolvedValue([]);
+    mockVirtualCard.mockResolvedValue({ intentId: 'intent-429', providerCardId: 'ic_429' });
+    mockStripe.issuing.cards.retrieve.mockResolvedValue({ status: 'canceled' });
+    mockAutoPagingToArray.mockRejectedValue(new Error('Too many requests'));
+
+    const report = await reconcileIntent('intent-429');
+
+    expect(report.inSync).toBe(false);
+    expect(report.stripe).toBeNull();
+    expect(report.discrepancies[0]).toContain('Too many requests');
+  });
+});
+
+describe('reconcileIntent — pagination (issue #88)', () => {
+  it('uses autoPagingToArray with a safety cap', async () => {
+    const txs = Array.from({ length: 250 }, (_, i) => ({
+      id: `itxn_${i}`,
+      amount: -10,
+      type: 'capture',
+    }));
+    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 2500, status: 'SETTLED' });
+    mockLedgerEntries.mockResolvedValue([]);
+    mockVirtualCard.mockResolvedValue({ intentId: 'intent-page', providerCardId: 'ic_page' });
+    mockStripe.issuing.cards.retrieve.mockResolvedValue({ status: 'canceled' });
+    mockAutoPagingToArray.mockResolvedValue(txs);
+
+    const report = await reconcileIntent('intent-page');
+
+    expect(mockAutoPagingToArray).toHaveBeenCalledWith({ limit: 1000 });
+    expect(report.stripe?.totalCaptured).toBe(2500);
+    expect(report.inSync).toBe(true);
+  });
+
+  it('flags a discrepancy when the safety cap is hit', async () => {
+    const txs = Array.from({ length: 1000 }, (_, i) => ({
+      id: `itxn_${i}`,
+      amount: -1,
+      type: 'capture',
+    }));
+    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 1000, status: 'SETTLED' });
+    mockLedgerEntries.mockResolvedValue([]);
+    mockVirtualCard.mockResolvedValue({ intentId: 'intent-cap', providerCardId: 'ic_cap' });
+    mockStripe.issuing.cards.retrieve.mockResolvedValue({ status: 'canceled' });
+    mockAutoPagingToArray.mockResolvedValue(txs);
+
+    const report = await reconcileIntent('intent-cap');
+
+    expect(report.inSync).toBe(false);
+    expect(report.discrepancies.some((d) => d.includes('truncated at 1000'))).toBe(true);
+  });
+});
+
+describe('reconcileIntent — missing virtualCard (issue #88)', () => {
+  it('returns inSync:true when neither pot nor card exists', async () => {
+    mockPot.mockResolvedValue(null);
+    mockLedgerEntries.mockResolvedValue([]);
+    mockVirtualCard.mockResolvedValue(null);
+
+    const report = await reconcileIntent('intent-empty');
+
+    expect(report.stripe).toBeNull();
+    expect(report.inSync).toBe(true);
+    expect(mockStripe.issuing.cards.retrieve).not.toHaveBeenCalled();
+  });
+
+  it('returns inSync:true when pot is ACTIVE with no settled funds (in-flight)', async () => {
+    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 0, status: 'ACTIVE' });
+    mockLedgerEntries.mockResolvedValue([{ type: 'RESERVE', amount: 5000 }]);
+    mockVirtualCard.mockResolvedValue(null);
+
+    const report = await reconcileIntent('intent-inflight');
+
+    expect(report.inSync).toBe(true);
+    expect(report.discrepancies).toHaveLength(0);
+  });
+
+  it('returns inSync:false when pot is SETTLED but no virtualCard record exists', async () => {
+    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 3500, status: 'SETTLED' });
+    mockLedgerEntries.mockResolvedValue([{ type: 'SETTLE', amount: 3500 }]);
+    mockVirtualCard.mockResolvedValue(null);
+
+    const report = await reconcileIntent('intent-orphaned-pot');
+
+    expect(report.inSync).toBe(false);
+    expect(
+      report.discrepancies.some((d) => d.includes('virtualCard missing') && d.includes('SETTLED')),
+    ).toBe(true);
+  });
+});
+
+describe('reconcileIntent — card status', () => {
+  it('reports a discrepancy when pot is SETTLED but Stripe card is still active', async () => {
+    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 3500, status: 'SETTLED' });
+    mockLedgerEntries.mockResolvedValue([]);
+    mockVirtualCard.mockResolvedValue({ intentId: 'intent-status', providerCardId: 'ic_active' });
+    mockStripe.issuing.cards.retrieve.mockResolvedValue({ status: 'active' });
+    mockAutoPagingToArray.mockResolvedValue([{ id: 'itxn_x', amount: -3500, type: 'capture' }]);
+
+    const report = await reconcileIntent('intent-status');
 
     expect(report.inSync).toBe(false);
     expect(
       report.discrepancies.some((d) => d.includes('expects card canceled but got active')),
     ).toBe(true);
   });
+});
 
-  it('returns stripe:null and inSync:true when no VirtualCard exists', async () => {
-    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 0, status: 'ACTIVE' });
-    mockLedgerEntries.mockResolvedValue([]);
-    mockVirtualCard.mockResolvedValue(null);
-
-    const report = await reconcileIntent('intent-4');
-
-    expect(report.stripe).toBeNull();
-    expect(report.inSync).toBe(true);
-    expect(report.discrepancies).toHaveLength(0);
-    expect(mockStripe.issuing.cards.retrieve).not.toHaveBeenCalled();
-  });
-
-  it('returns potStatus:null and inSync:true when no Pot exists', async () => {
+describe('reconcileIntent — internal report fields', () => {
+  it('reports zero balances and null potStatus when no pot exists', async () => {
     mockPot.mockResolvedValue(null);
     mockLedgerEntries.mockResolvedValue([]);
     mockVirtualCard.mockResolvedValue(null);
 
-    const report = await reconcileIntent('intent-5');
+    const report = await reconcileIntent('intent-no-pot');
 
     expect(report.internal.potStatus).toBeNull();
     expect(report.internal.reserved).toBe(0);
     expect(report.internal.settled).toBe(0);
     expect(report.inSync).toBe(true);
+  });
+
+  it('serialises ledger entries into "TYPE:amount" strings', async () => {
+    mockPot.mockResolvedValue(null);
+    mockLedgerEntries.mockResolvedValue([
+      { type: 'RESERVE', amount: 5000 },
+      { type: 'SETTLE', amount: 3500 },
+    ]);
+    mockVirtualCard.mockResolvedValue(null);
+
+    const report = await reconcileIntent('intent-ledger');
+
+    expect(report.internal.ledgerEntries).toEqual(['RESERVE:5000', 'SETTLE:3500']);
   });
 });

--- a/tests/unit/payments/stripeProvider.test.ts
+++ b/tests/unit/payments/stripeProvider.test.ts
@@ -31,10 +31,13 @@ describe('StripePaymentProvider', () => {
   });
 
   describe('metadata', () => {
-    it('exposes Stripe provider metadata with EUR currency', () => {
-      expect(provider.metadata).toEqual({
+    it('exposes Stripe provider metadata with EUR currency + per-transaction auth', () => {
+      expect(provider.metadata).toMatchObject({
         id: PaymentProvider.STRIPE,
         currency: 'eur',
+        authorizationModel: 'per_transaction',
+        autoCancelAfterUse: false,
+        supportsFreeze: true,
       });
     });
   });

--- a/tests/unit/telegram/callbackHandler.test.ts
+++ b/tests/unit/telegram/callbackHandler.test.ts
@@ -161,7 +161,7 @@ describe('handleTelegramCallback — link_confirm', () => {
     expect(mockSetSession).toHaveBeenCalledWith(
       12345678,
       expect.objectContaining({
-        step: 'awaiting_email',
+        step: 'awaiting_provider',
         agentId: 'ag_test',
         pairingCode: 'ABCD1234',
       }),
@@ -169,8 +169,27 @@ describe('handleTelegramCallback — link_confirm', () => {
     expect(mockEditMessageText).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
-      expect.stringContaining('email'),
+      expect.stringContaining('payment provider'),
       expect.any(Object),
+    );
+  });
+
+  it('advances to awaiting_email when provider is chosen', async () => {
+    const session = {
+      step: 'awaiting_provider' as const,
+      agentId: 'ag_test',
+      pairingCode: 'ABCD1234',
+    };
+    mockGetSession.mockResolvedValue(session);
+
+    await handleTelegramCallback(makeUpdate('signup_provider', 'PRIVACY_COM', 'cb-sp1', 12345678));
+
+    expect(mockSetSession).toHaveBeenCalledWith(
+      12345678,
+      expect.objectContaining({
+        step: 'awaiting_email',
+        paymentProvider: 'PRIVACY_COM',
+      }),
     );
   });
 

--- a/tests/unit/telegram/signupHandler.test.ts
+++ b/tests/unit/telegram/signupHandler.test.ts
@@ -185,6 +185,7 @@ describe('email step handling', () => {
     step: 'awaiting_email' as const,
     agentId: 'ag_test',
     pairingCode: 'ABCD1234',
+    paymentProvider: 'STRIPE' as const,
   };
 
   it('creates user and marks code claimed on valid email', async () => {
@@ -211,6 +212,7 @@ describe('email step handling', () => {
           mainBalance: 1_000_000,
           maxBudgetPerIntent: 50000,
           apiKeyHash: expect.any(String),
+          paymentProvider: 'STRIPE',
         }),
       }),
     );


### PR DESCRIPTION
## Summary

Implements #106 and closes the remaining ACs on #105. **Stacked on top of #129** — merging #129 first is recommended; this PR will then merge cleanly against `main`.

## Privacy.com integration (#106)

- **Fire-and-forget model**: `SINGLE_USE` cards with `spend_limit` + `spend_limit_duration: TRANSACTION`. Card self-closes after first transaction — there is no per-authorization webhook to react to, all limits are baked in at issuance.
- **No sandbox access** — HTTP client is injectable for tests and hits `https://api.privacy.com/v1/` in production. `Authorization: api-key <TOKEN>` header.
- **Reveal cache**: Privacy returns PAN/CVV on the create response only (no separate reveal endpoint), so we hold them in process memory with a 10-minute TTL and purge on first reveal. PAN never touches the DB.
- **Webhook route**: `/v1/webhooks/privacy` with HMAC-SHA256 signature verification. ⚠️ The exact header and algorithm aren't publicly documented — both are configurable via `PRIVACY_WEBHOOK_SIGNATURE_HEADER` and must be verified against the Privacy.com dashboard before going live. Flagged in code comments.
- **Unsupported ops**: `freezeCard` throws `UnsupportedProviderOperationError` for Privacy (SINGLE_USE has no PAUSED state). `cancelCard` is best-effort — already-closed errors are swallowed.
- **Orchestrator**: `applyPostCheckoutCancelPolicy` reads `metadata.autoCancelAfterUse` and skips cancelCard when true; respects `metadata.supportsFreeze` before attempting MANUAL freeze.

## Provider selection at signup (#105 remaining ACs)

- New `awaiting_provider` session step between "confirm" and "email"
- Callback handler shows a provider-choice keyboard with the tradeoff copy (per-transaction approval for Stripe vs fire-and-forget for Privacy)
- Signup handler seeds `paymentProvider` on the User and sets `mainBalance = 1_000_000` (smallest units) — 10 000 EUR for Stripe, 10 000 USD for Privacy.com
- Provider is locked at signup for v0.1 (switching tracked in #128)

## Restored contract fields

PR #129 trimmed `ProviderMetadata` to `{id, currency}` on reviewer feedback (drop unused symbols). This PR re-introduces `displayName`, `authorizationModel`, `autoCancelAfterUse`, `supportsFreeze`, and `UnsupportedProviderOperationError` — now all consumed by the Privacy provider and the orchestrator.

## Test plan

- [x] `npm test -- --testPathPattern=tests/unit` — **382 pass** (19 new tests):
  - `privacyProvider.test.ts`: metadata shape, SINGLE_USE issuance, PAN-not-persisted, client-side dedup, reveal cache take-once, freeze-throws-unsupported, best-effort cancel
  - `privacyWebhook.test.ts`: HMAC verification, card_token correlation, missing/unknown token handling
  - Updated `callbackHandler.test.ts` for the new `awaiting_provider` step
  - Updated `signupHandler.test.ts` for `paymentProvider` persistence on User
  - Updated `onboarding.test.ts` integration test to include the provider-choice step
- [x] `npm run test:integration` — onboarding + apiKeyAuth + menuHandler + stripeWebhook pass; remaining failures are Stripe-API-dependent (`checkoutSimulator`, `telegramApprovalCheckout`) and expected without real `STRIPE_SECRET_KEY`
- [x] `npx tsc --noEmit` — clean
- [x] `npm run format:check` — clean

## Out of scope (tracked separately)

- Provider switching after signup (#128)
- Replacing the injectable fetch mock with real Privacy.com sandbox calls (blocked on sandbox access)
- Confirming Privacy.com's actual webhook signature scheme against their dashboard