### PR TITLE
feat(#16): one-command setup script + Makefile + friendly env validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,12 @@ STRIPE_WEBHOOK_SECRET=whsec_placeholder
 WORKER_API_KEY=local-dev-worker-key
 PORT=3000
 
+# Node environment: development | test | production
+NODE_ENV=development
+
+# Payment provider selection (stripe is the only supported provider today)
+PAYMENT_PROVIDER=stripe
+
 # Logging — valid levels: trace, debug, info, warn, error, fatal (default: info)
 # Pretty-printed output is enabled automatically when stdout is a TTY (interactive terminal).
 # Set to debug for verbose request/response logging during local development.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,60 @@
+## Trusted Payment Infrastructure for Agents — developer Makefile
+##
+## Thin wrappers around `npm run` scripts and scripts/setup.sh so common dev
+## workflows are discoverable via `make help`. Use `make -n <target>` to dry-run.
+
+SHELL := /usr/bin/env bash
+
+.DEFAULT_GOAL := help
+.PHONY: help setup dev worker test test-integration migrate migrate-create seed reset lint format format-check build clean infra infra-down
+
+help: ## Show this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nAvailable targets:\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+setup: ## One-command first-run setup (prereqs, .env, docker, migrate, seed).
+	./scripts/setup.sh
+
+dev: ## Start the Fastify dev server with hot reload.
+	npm run dev
+
+worker: ## Start the stub BullMQ worker (simulates OpenClaw locally).
+	npm run worker
+
+test: ## Run fast unit tests (no DB/Redis required).
+	npm test
+
+test-integration: ## Run integration tests (requires docker compose up -d).
+	npm run test:integration
+
+migrate: ## Apply pending Prisma migrations (deploy mode, CI-safe).
+	npx prisma migrate deploy
+
+migrate-create: ## Create and apply a new Prisma migration (interactive).
+	npm run db:migrate
+
+seed: ## Seed the database with the demo user.
+	npm run seed
+
+reset: ## Reset the database (drops all data) and re-run migrations + seed.
+	npm run db:reset
+
+lint: ## Run ESLint across src + tests.
+	npm run lint
+
+format: ## Format all TypeScript sources with Prettier.
+	npm run format
+
+format-check: ## Verify Prettier formatting without writing.
+	npm run format:check
+
+build: ## Compile TypeScript to dist/.
+	npm run build
+
+infra: ## Start Postgres + Redis via docker compose.
+	docker compose up -d
+
+infra-down: ## Stop Postgres + Redis containers.
+	docker compose down
+
+clean: ## Remove build artefacts and node_modules.
+	rm -rf dist node_modules

--- a/README.md
+++ b/README.md
@@ -262,20 +262,31 @@ Every purchase is a `PurchaseIntent` tracked through an explicit state machine. 
 - **Stripe account** with Issuing enabled — see [docs/stripe-setup.md](docs/stripe-setup.md) for the full walkthrough
 - **Telegram bot token** (optional) — for approval notifications and user signup; see [docs/telegram-setup.md](docs/telegram-setup.md)
 
-### 1. Install and configure
+### 1. One-command setup (recommended)
 
 ```bash
-git clone https://github.com/your-org/trustedpaymentinfrastructureforagents
+git clone https://github.com/JonasBaeumer/trustedpaymentinfrastructureforagents
 cd trustedpaymentinfrastructureforagents
-npm install
-cp .env.example .env
+./scripts/setup.sh        # or: make setup
 ```
 
-Open `.env` and fill in at minimum:
+The script checks prerequisites (Node 20+, Docker, Stripe CLI), creates `.env`
+from `.env.example`, prompts for the Stripe + Telegram values, starts
+Postgres + Redis, installs dependencies, and runs `prisma migrate deploy`
+followed by `npm run seed`. Use `./scripts/setup.sh --yes` for an
+unattended run (CI-safe).
 
-```env
-STRIPE_SECRET_KEY=sk_test_...
-WORKER_API_KEY=local-dev-worker-key
+Once it finishes, skip to **step 4** to start the server.
+
+<details>
+<summary>Manual setup (fallback)</summary>
+
+```bash
+npm install
+cp .env.example .env
+# Open .env and fill in at minimum:
+#   STRIPE_SECRET_KEY=sk_test_...
+#   WORKER_API_KEY=local-dev-worker-key
 ```
 
 Everything else has safe defaults for local development.
@@ -284,6 +295,7 @@ Everything else has safe defaults for local development.
 
 ```bash
 docker compose up -d    # starts Postgres 16 + Redis 7
+# or: make infra
 ```
 
 ### 3. Migrate and seed
@@ -293,11 +305,20 @@ npm run db:migrate      # creates all tables
 npm run seed            # creates demo user: demo@agentpay.dev, £1 000 balance
 ```
 
+</details>
+
 ### 4. Start the server
 
 ```bash
 npm run dev             # hot-reload dev server on http://localhost:3000
+# or: make dev
 ```
+
+Run `make help` to see every common developer task in one place.
+
+If any required environment variable is missing or malformed, the server
+prints a single human-readable block listing exactly which keys need
+attention (no stack trace) and exits.
 
 ### 5. (Optional) Start the stub worker
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3669,6 +3669,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Trusted Payment Infrastructure for Agents — first-run setup script.
+#
+# Guides a fresh clone end-to-end:
+#   1. Checks prerequisites (node, docker, optional stripe CLI)
+#   2. Creates .env from .env.example and prompts for required values
+#   3. Boots Postgres + Redis via docker compose and waits for readiness
+#   4. Installs npm deps, generates Prisma client, migrates, seeds
+#   5. Prints next-step instructions
+#
+# Flags:
+#   --yes, -y        non-interactive; accept defaults, skip prompts (CI-safe)
+#   --skip-seed      skip the seed step
+#   -h, --help       show this help
+
+set -euo pipefail
+
+if [[ -t 1 ]]; then
+  BOLD='\033[1m'; GREEN='\033[0;32m'; YELLOW='\033[0;33m'; RED='\033[0;31m'; BLUE='\033[0;34m'; DIM='\033[2m'; RESET='\033[0m'
+else
+  BOLD=''; GREEN=''; YELLOW=''; RED=''; BLUE=''; DIM=''; RESET=''
+fi
+
+info()    { printf "${BLUE}==>${RESET} %s\n" "$*"; }
+success() { printf "${GREEN}✓${RESET}  %s\n" "$*"; }
+warn()    { printf "${YELLOW}!${RESET}  %s\n" "$*"; }
+error()   { printf "${RED}✗${RESET}  %s\n" "$*" >&2; }
+step()    { printf "\n${BOLD}%s${RESET}\n" "$*"; }
+
+YES=0
+SKIP_SEED=0
+
+for arg in "$@"; do
+  case "$arg" in
+    -y|--yes) YES=1 ;;
+    --skip-seed) SKIP_SEED=1 ;;
+    -h|--help)
+      sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) error "Unknown argument: $arg"; exit 2 ;;
+  esac
+done
+
+# Force non-interactive mode in CI environments even if --yes wasn't passed.
+if [[ "${CI:-}" == "true" || "${CI:-}" == "1" ]]; then
+  YES=1
+fi
+
+# Resolve repo root (one level up from scripts/)
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." &>/dev/null && pwd)"
+cd "$REPO_ROOT"
+
+# ---------------------------------------------------------------------------
+# 1. Prerequisite checks
+# ---------------------------------------------------------------------------
+step "1/5 Checking prerequisites"
+
+check_node() {
+  if ! command -v node >/dev/null 2>&1; then
+    error "Node.js is not installed. Install Node 20+ from https://nodejs.org"
+    return 1
+  fi
+  local major
+  major="$(node -e 'process.stdout.write(String(process.versions.node.split(".")[0]))')"
+  if (( major < 20 )); then
+    error "Node $major found — this project requires Node 20 or newer."
+    return 1
+  fi
+  success "Node $(node -v)"
+}
+
+check_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    error "Docker is not installed. Install Docker Desktop: https://www.docker.com/products/docker-desktop"
+    return 1
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    error "Docker daemon is not running. Start Docker Desktop and re-run this script."
+    return 1
+  fi
+  if ! docker compose version >/dev/null 2>&1; then
+    error "'docker compose' plugin is missing. Update Docker Desktop or install the compose plugin."
+    return 1
+  fi
+  success "Docker $(docker version --format '{{.Server.Version}}' 2>/dev/null || echo 'running')"
+}
+
+check_stripe() {
+  if command -v stripe >/dev/null 2>&1; then
+    success "Stripe CLI $(stripe --version 2>/dev/null | awk '{print $2}')"
+  else
+    warn "Stripe CLI not found. Optional but recommended for local webhook forwarding."
+    warn "Install: https://stripe.com/docs/stripe-cli"
+  fi
+}
+
+check_platform() {
+  case "$(uname -s)" in
+    Darwin|Linux) ;;
+    MINGW*|MSYS*|CYGWIN*)
+      warn "Native Windows shells are not supported. Use WSL2 for the best experience."
+      ;;
+    *) warn "Untested platform: $(uname -s). Proceeding anyway." ;;
+  esac
+}
+
+check_platform
+check_node
+check_docker
+check_stripe
+
+# ---------------------------------------------------------------------------
+# 2. .env bootstrap
+# ---------------------------------------------------------------------------
+step "2/5 Configuring .env"
+
+if [[ ! -f .env.example ]]; then
+  error ".env.example is missing. Are you in the project root?"
+  exit 1
+fi
+
+if [[ -f .env ]]; then
+  success ".env already exists — leaving existing values untouched"
+else
+  cp .env.example .env
+  success "Created .env from .env.example"
+
+  if (( YES == 0 )); then
+    prompt_value() {
+      local key="$1" description="$2" default="$3" reply=""
+      printf "  %s\n    ${DIM}%s${RESET}\n    [default: %s]: " "$key" "$description" "${default:-<empty>}"
+      IFS= read -r reply || true
+      reply="${reply:-$default}"
+      # Replace or append the key=value pair (portable sed)
+      if grep -q "^${key}=" .env; then
+        local escaped
+        escaped="$(printf '%s' "$reply" | sed -e 's/[\/&]/\\&/g')"
+        sed -i.bak -e "s/^${key}=.*/${key}=${escaped}/" .env && rm -f .env.bak
+      else
+        printf "\n%s=%s\n" "$key" "$reply" >> .env
+      fi
+    }
+    info "Press Enter to accept defaults. You can edit .env later."
+    prompt_value STRIPE_SECRET_KEY "Stripe test-mode secret key (sk_test_...)" "sk_test_placeholder"
+    prompt_value STRIPE_WEBHOOK_SECRET "Stripe webhook signing secret (whsec_...)" "whsec_placeholder"
+    prompt_value TELEGRAM_BOT_TOKEN "Telegram bot token (optional)" ""
+    prompt_value TELEGRAM_WEBHOOK_SECRET "Telegram webhook secret (optional)" ""
+  else
+    info "Non-interactive mode — keeping default placeholder values in .env"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Docker compose + readiness
+# ---------------------------------------------------------------------------
+step "3/5 Starting Postgres + Redis"
+
+docker compose up -d >/dev/null
+success "docker compose up -d"
+
+POSTGRES_CONTAINER="$(docker compose ps --format '{{.Name}}' postgres | head -n1)"
+REDIS_CONTAINER="$(docker compose ps --format '{{.Name}}' redis | head -n1)"
+
+wait_for() {
+  local label="$1" cmd="$2" timeout="${3:-60}"
+  local elapsed=0
+  while (( elapsed < timeout )); do
+    if eval "$cmd" >/dev/null 2>&1; then
+      success "$label is ready"
+      return 0
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+  error "$label did not become ready within ${timeout}s"
+  return 1
+}
+
+wait_for "Postgres" "docker exec ${POSTGRES_CONTAINER} pg_isready -U postgres"
+wait_for "Redis"    "docker exec ${REDIS_CONTAINER} redis-cli PING | grep -q PONG"
+
+# ---------------------------------------------------------------------------
+# 4. Dependencies + Prisma + seed
+# ---------------------------------------------------------------------------
+step "4/5 Installing dependencies and migrating database"
+
+if [[ -d node_modules && -f package-lock.json ]]; then
+  info "node_modules present — running npm install to reconcile the lockfile"
+fi
+npm install --no-audit --no-fund
+success "npm install"
+
+npx prisma generate >/dev/null
+success "prisma generate"
+
+npx prisma migrate deploy
+success "prisma migrate deploy"
+
+if (( SKIP_SEED == 0 )); then
+  npm run seed
+  success "seed"
+else
+  warn "Skipping seed (per --skip-seed)"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Next steps
+# ---------------------------------------------------------------------------
+step "5/5 All set"
+
+cat <<EOF
+
+${GREEN}Setup complete.${RESET} Next steps:
+
+  1. Start the dev server:
+       ${BOLD}npm run dev${RESET}       # or ${BOLD}make dev${RESET}
+
+  2. (Optional) Run the stub worker to simulate OpenClaw:
+       ${BOLD}npm run worker${RESET}    # or ${BOLD}make worker${RESET}
+
+  3. (Optional) Forward Stripe webhooks for Issuing events:
+       ${BOLD}stripe listen --forward-to localhost:3000/v1/webhooks/stripe${RESET}
+       Copy the printed whsec_... into .env as STRIPE_WEBHOOK_SECRET.
+
+  4. Run the test suite:
+       ${BOLD}npm test${RESET}          # fast unit tests
+       ${BOLD}make test-integration${RESET}  # integration tests (uses running Postgres + Redis)
+
+Health check:
+  curl http://localhost:3000/health
+
+EOF

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,24 +1,92 @@
 import dotenv from 'dotenv';
+import { z } from 'zod';
+
 dotenv.config();
 
-function requireEnv(name: string): string {
-  const value = process.env[name];
-  if (!value) throw new Error(`Missing required env var: ${name}`);
-  return value;
+const nonEmpty = (label: string) =>
+  z
+    .string({ required_error: `${label} is required` })
+    .trim()
+    .min(1, `${label} is required`);
+
+export const envSchema = z.object({
+  DATABASE_URL: nonEmpty('DATABASE_URL').pipe(
+    z
+      .string()
+      .regex(
+        /^postgres(ql)?:\/\//,
+        'DATABASE_URL must be a PostgreSQL connection string (postgresql://...)',
+      ),
+  ),
+  REDIS_URL: nonEmpty('REDIS_URL').pipe(
+    z
+      .string()
+      .regex(
+        /^redis(s)?:\/\//,
+        'REDIS_URL must be a Redis connection string (redis://... or rediss://...)',
+      ),
+  ),
+  WORKER_API_KEY: nonEmpty('WORKER_API_KEY'),
+  STRIPE_SECRET_KEY: z.string().default('sk_test_placeholder'),
+  STRIPE_WEBHOOK_SECRET: z.string().default('whsec_placeholder'),
+  PORT: z
+    .string()
+    .default('3000')
+    .transform((v) => Number.parseInt(v, 10))
+    .pipe(z.number().int().positive().max(65535)),
+  NODE_ENV: z.string().default('development'),
+  TELEGRAM_BOT_TOKEN: z.string().default(''),
+  TELEGRAM_WEBHOOK_SECRET: z.string().default(''),
+  TELEGRAM_TEST_CHAT_ID: z.string().default(''),
+  TELEGRAM_MOCK: z
+    .string()
+    .default('false')
+    .transform((v) => v === 'true'),
+  PAYMENT_PROVIDER: z.string().default('stripe'),
+  LOG_LEVEL: z
+    .enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal'])
+    .default('info'),
+});
+
+export type Env = z.infer<typeof envSchema>;
+
+export function formatEnvValidationErrors(error: z.ZodError): string {
+  const lines = error.issues.map((issue) => {
+    const name = issue.path.join('.') || '(root)';
+    return `  - ${name}: ${issue.message}`;
+  });
+  return [
+    '',
+    'Environment configuration is invalid. Please fix the following before starting:',
+    ...lines,
+    '',
+    'Tip: copy .env.example to .env and fill in the required values,',
+    'or run `./scripts/setup.sh` for a guided setup.',
+    '',
+  ].join('\n');
 }
 
-export const env = {
-  DATABASE_URL: requireEnv('DATABASE_URL'),
-  REDIS_URL: requireEnv('REDIS_URL'),
-  STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY || 'sk_test_placeholder',
-  STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET || 'whsec_placeholder',
-  WORKER_API_KEY: requireEnv('WORKER_API_KEY'),
-  PORT: parseInt(process.env.PORT || '3000', 10),
-  NODE_ENV: process.env.NODE_ENV || 'development',
-  TELEGRAM_BOT_TOKEN: process.env.TELEGRAM_BOT_TOKEN || '',
-  TELEGRAM_WEBHOOK_SECRET: process.env.TELEGRAM_WEBHOOK_SECRET || '',
-  TELEGRAM_TEST_CHAT_ID: process.env.TELEGRAM_TEST_CHAT_ID || '',
-  TELEGRAM_MOCK: process.env.TELEGRAM_MOCK === 'true',
-  PAYMENT_PROVIDER: process.env.PAYMENT_PROVIDER || 'stripe',
-  LOG_LEVEL: process.env.LOG_LEVEL || 'info',
-};
+export function validateEnv(source: NodeJS.ProcessEnv = process.env): Env {
+  const parsed = envSchema.safeParse(source);
+  if (!parsed.success) {
+    const message = formatEnvValidationErrors(parsed.error);
+    const err = new Error(message);
+    err.name = 'EnvValidationError';
+    throw err;
+  }
+  return parsed.data;
+}
+
+function loadEnv(): Env {
+  try {
+    return validateEnv();
+  } catch (err) {
+    if (err instanceof Error && err.name === 'EnvValidationError') {
+      process.stderr.write(`${err.message}\n`);
+      process.exit(1);
+    }
+    throw err;
+  }
+}
+
+export const env: Env = loadEnv();

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -43,9 +43,7 @@ export const envSchema = z.object({
     .default('false')
     .transform((v) => v === 'true'),
   PAYMENT_PROVIDER: z.string().default('stripe'),
-  LOG_LEVEL: z
-    .enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal'])
-    .default('info'),
+  LOG_LEVEL: z.enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal']).default('info'),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -66,7 +66,7 @@ export function formatEnvValidationErrors(error: z.ZodError): string {
   ].join('\n');
 }
 
-export function validateEnv(source: NodeJS.ProcessEnv = process.env): Env {
+export function validateEnv(source: Record<string, string | undefined> = process.env): Env {
   const parsed = envSchema.safeParse(source);
   if (!parsed.success) {
     const message = formatEnvValidationErrors(parsed.error);

--- a/tests/unit/config/env.test.ts
+++ b/tests/unit/config/env.test.ts
@@ -1,0 +1,71 @@
+import { validateEnv, formatEnvValidationErrors, envSchema } from '@/config/env';
+
+describe('env validator', () => {
+  const VALID: NodeJS.ProcessEnv = {
+    DATABASE_URL: 'postgresql://postgres:postgres@localhost:5432/agentpay',
+    REDIS_URL: 'redis://localhost:6379',
+    WORKER_API_KEY: 'local-dev-worker-key',
+  };
+
+  it('accepts a minimal valid configuration and applies defaults', () => {
+    const env = validateEnv(VALID);
+    expect(env.DATABASE_URL).toBe(VALID.DATABASE_URL);
+    expect(env.PORT).toBe(3000);
+    expect(env.NODE_ENV).toBe('development');
+    expect(env.LOG_LEVEL).toBe('info');
+    expect(env.TELEGRAM_MOCK).toBe(false);
+    expect(env.PAYMENT_PROVIDER).toBe('stripe');
+  });
+
+  it('coerces PORT and TELEGRAM_MOCK from strings', () => {
+    const env = validateEnv({ ...VALID, PORT: '8080', TELEGRAM_MOCK: 'true' });
+    expect(env.PORT).toBe(8080);
+    expect(env.TELEGRAM_MOCK).toBe(true);
+  });
+
+  it('throws an EnvValidationError listing every missing required variable', () => {
+    expect.assertions(6);
+    try {
+      validateEnv({});
+    } catch (err) {
+      const e = err as Error;
+      expect(e.name).toBe('EnvValidationError');
+      expect(e.message).toContain('DATABASE_URL');
+      expect(e.message).toContain('REDIS_URL');
+      expect(e.message).toContain('WORKER_API_KEY');
+      expect(e.message).toContain('Environment configuration is invalid');
+      expect(e.message).toContain('./scripts/setup.sh');
+    }
+  });
+
+  it('rejects malformed DATABASE_URL and REDIS_URL values', () => {
+    try {
+      validateEnv({
+        ...VALID,
+        DATABASE_URL: 'mysql://localhost',
+        REDIS_URL: 'http://localhost',
+      });
+      fail('expected validation to throw');
+    } catch (err) {
+      const e = err as Error;
+      expect(e.name).toBe('EnvValidationError');
+      expect(e.message).toMatch(/DATABASE_URL.*PostgreSQL/);
+      expect(e.message).toMatch(/REDIS_URL.*Redis/);
+    }
+  });
+
+  it('rejects invalid LOG_LEVEL values', () => {
+    expect(() => validateEnv({ ...VALID, LOG_LEVEL: 'loud' })).toThrow(/LOG_LEVEL/);
+  });
+
+  it('formatEnvValidationErrors produces one bullet per issue', () => {
+    const parsed = envSchema.safeParse({});
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      const formatted = formatEnvValidationErrors(parsed.error);
+      const bullets = formatted.split('\n').filter((line) => line.startsWith('  - '));
+      expect(bullets.length).toBeGreaterThanOrEqual(3);
+      expect(bullets.join('\n')).toMatch(/DATABASE_URL/);
+    }
+  });
+});

--- a/tests/unit/config/env.test.ts
+++ b/tests/unit/config/env.test.ts
@@ -1,7 +1,9 @@
 import { validateEnv, formatEnvValidationErrors, envSchema } from '@/config/env';
 
+type EnvSource = Record<string, string | undefined>;
+
 describe('env validator', () => {
-  const VALID: NodeJS.ProcessEnv = {
+  const VALID: EnvSource = {
     DATABASE_URL: 'postgresql://postgres:postgres@localhost:5432/agentpay',
     REDIS_URL: 'redis://localhost:6379',
     WORKER_API_KEY: 'local-dev-worker-key',
@@ -39,19 +41,20 @@ describe('env validator', () => {
   });
 
   it('rejects malformed DATABASE_URL and REDIS_URL values', () => {
+    let caught: Error | undefined;
     try {
       validateEnv({
         ...VALID,
         DATABASE_URL: 'mysql://localhost',
         REDIS_URL: 'http://localhost',
       });
-      fail('expected validation to throw');
     } catch (err) {
-      const e = err as Error;
-      expect(e.name).toBe('EnvValidationError');
-      expect(e.message).toMatch(/DATABASE_URL.*PostgreSQL/);
-      expect(e.message).toMatch(/REDIS_URL.*Redis/);
+      caught = err as Error;
     }
+    expect(caught).toBeDefined();
+    expect(caught?.name).toBe('EnvValidationError');
+    expect(caught?.message).toMatch(/DATABASE_URL.*PostgreSQL/);
+    expect(caught?.message).toMatch(/REDIS_URL.*Redis/);
   });
 
   it('rejects invalid LOG_LEVEL values', () => {


### PR DESCRIPTION
## Summary

Closes #16.

Gets a fresh clone running with a single command and replaces stack-trace crashes on missing env vars with a readable error block.

- `scripts/setup.sh` walks through prereq checks (Node 20+, Docker, optional Stripe CLI), bootstraps `.env`, boots Postgres + Redis via docker compose and waits for readiness, runs `npm install`, `prisma generate`, `prisma migrate deploy`, and `npm run seed`. Supports `--yes`, `--skip-seed`, and picks up `CI=true` for unattended runs.
- `Makefile` wraps the common dev flows (`setup`, `dev`, `worker`, `test`, `test-integration`, `migrate`, `seed`, `reset`, `lint`, `format`, `build`, `infra`, `clean`) with `make help`.
- `src/config/env.ts` is rewritten around a Zod schema. Missing/invalid values now print a single block listing exactly what is wrong (one bullet per issue) and `process.exit(1)` — no stack trace.
- README Quick Start leads with `./scripts/setup.sh`; the manual steps are preserved as a collapsible fallback.
- `.env.example` gains explicit `NODE_ENV` and `PAYMENT_PROVIDER` entries.

## Test plan

- [x] `npm test` (361 unit tests pass, incl. 6 new cases in `tests/unit/config/env.test.ts` covering defaults, coercion, malformed URLs, invalid LOG_LEVEL, and aggregate error formatting).
- [x] `./scripts/setup.sh --yes --skip-seed` on the running stack completes end-to-end.
- [x] `make help` renders all targets; `make test` delegates correctly.
- [x] Manual repro: running the server with all required vars missing prints the friendly block and exits — no stack trace.

## Acceptance checklist (from the issue)

- [x] `./scripts/setup.sh` runs end-to-end on a clean clone (macOS verified; bash-only, Linux-compatible syntax).
- [x] Missing env vars produce a clear startup error, not a stack trace.
- [x] README Getting Started section references the script as the entry point.
- [x] Makefile covers all common dev workflows.