### PR TITLE
feat(#17): propagate agentId into AuditEvent and structured logs

### DIFF
--- a/prisma/migrations/20260421000000_add_agent_id_to_audit_event/migration.sql
+++ b/prisma/migrations/20260421000000_add_agent_id_to_audit_event/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "AuditEvent" ADD COLUMN "agentId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "AuditEvent_intentId_agentId_idx" ON "AuditEvent"("intentId", "agentId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -153,11 +153,14 @@ model AuditEvent {
   id        String   @id @default(cuid())
   intentId  String?
   actor     String
+  agentId   String?
   event     String
   payload   Json     @default("{}")
   createdAt DateTime @default(now())
 
   intent    PurchaseIntent? @relation(fields: [intentId], references: [id])
+
+  @@index([intentId, agentId])
 }
 
 model IdempotencyRecord {

--- a/src/api/middleware/agentContext.ts
+++ b/src/api/middleware/agentContext.ts
@@ -1,0 +1,47 @@
+import { FastifyRequest, FastifyReply } from 'fastify';
+
+// Fastify augments: expose request.agentId on any handler under /v1/agent/*.
+declare module 'fastify' {
+  interface FastifyRequest {
+    agentId: string | null;
+  }
+}
+
+function extractIntentId(request: FastifyRequest): string | null {
+  const fromParams = (request.params as { intentId?: string } | undefined)?.intentId;
+  if (typeof fromParams === 'string' && fromParams) return fromParams;
+  const fromBody = (request.body as { intentId?: string } | undefined)?.intentId;
+  if (typeof fromBody === 'string' && fromBody) return fromBody;
+  return null;
+}
+
+/**
+ * Attaches per-request agent context for every /v1/agent/* route:
+ *   - Parses the X-Agent-Id header and exposes it as `request.agentId`.
+ *   - Rebinds `request.log` to a child logger carrying
+ *     { agentId?, intentId?, route } so any log emitted by this handler
+ *     (or by a downstream call using request.log) inherits that context.
+ *   - Emits a single INFO log line at request start so Fastify's stream
+ *     always contains a structured entry with the full context even when
+ *     Fastify's own request-completion log does not.
+ *
+ * Called via fastify.addHook('onRequest', ...) scoped to the agent plugin.
+ */
+export async function agentContextMiddleware(
+  request: FastifyRequest,
+  _reply: FastifyReply,
+): Promise<void> {
+  const rawHeader = request.headers['x-agent-id'];
+  const agentId = typeof rawHeader === 'string' && rawHeader.trim() ? rawHeader.trim() : null;
+  request.agentId = agentId;
+
+  const intentId = extractIntentId(request);
+  const route = request.routerPath ?? request.url.split('?')[0];
+
+  const bindings: Record<string, string> = { route };
+  if (agentId) bindings.agentId = agentId;
+  if (intentId) bindings.intentId = intentId;
+
+  request.log = request.log.child(bindings);
+  request.log.info({ method: request.method }, 'Agent request received');
+}

--- a/src/api/routes/agent.ts
+++ b/src/api/routes/agent.ts
@@ -55,11 +55,7 @@ export async function agentRoutes(fastify: FastifyInstance): Promise<void> {
       }
 
       // SEARCHING → QUOTED (stores quote data in metadata via orchestrator)
-      await receiveQuote(
-        intentId,
-        { merchantName, merchantUrl, price, currency },
-        request.agentId,
-      );
+      await receiveQuote(intentId, { merchantName, merchantUrl, price, currency }, request.agentId);
 
       // QUOTED → AWAITING_APPROVAL
       await requestApproval(intentId, request.agentId);

--- a/src/api/routes/agent.ts
+++ b/src/api/routes/agent.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { workerAuthMiddleware } from '@/api/middleware/auth';
+import { agentContextMiddleware } from '@/api/middleware/agentContext';
 import { agentQuoteSchema, agentResultSchema, agentRegisterSchema } from '@/api/validators/agent';
 import { IntentStatus } from '@/contracts';
 import {
@@ -26,6 +27,11 @@ function generatePairingCode(): string {
 }
 
 export async function agentRoutes(fastify: FastifyInstance): Promise<void> {
+  // Bind { agentId, route, intentId? } to request.log for every /v1/agent/* request
+  // and expose request.agentId to handlers. Runs before workerAuthMiddleware so
+  // even rejected requests are logged with their agentId for traceability.
+  fastify.addHook('onRequest', agentContextMiddleware);
+
   // POST /v1/agent/quote — worker posts search result
   // Flow: SEARCHING → QUOTED → AWAITING_APPROVAL
   fastify.post(
@@ -49,10 +55,14 @@ export async function agentRoutes(fastify: FastifyInstance): Promise<void> {
       }
 
       // SEARCHING → QUOTED (stores quote data in metadata via orchestrator)
-      await receiveQuote(intentId, { merchantName, merchantUrl, price, currency });
+      await receiveQuote(
+        intentId,
+        { merchantName, merchantUrl, price, currency },
+        request.agentId,
+      );
 
       // QUOTED → AWAITING_APPROVAL
-      await requestApproval(intentId);
+      await requestApproval(intentId, request.agentId);
 
       // Fire-and-forget Telegram notification — must not block the HTTP response
       sendApprovalRequest(intentId).catch((err: unknown) =>
@@ -91,10 +101,10 @@ export async function agentRoutes(fastify: FastifyInstance): Promise<void> {
       }
 
       if (success) {
-        await completeCheckout(intentId, actualAmount ?? 0);
+        await completeCheckout(intentId, actualAmount ?? 0, request.agentId);
         await settleIntent(intentId, actualAmount ?? 0);
       } else {
-        await failCheckout(intentId, errorMessage ?? 'Checkout failed');
+        await failCheckout(intentId, errorMessage ?? 'Checkout failed', request.agentId);
         await returnIntent(intentId);
       }
 

--- a/src/api/routes/users.ts
+++ b/src/api/routes/users.ts
@@ -109,6 +109,7 @@ export async function usersRoutes(fastify: FastifyInstance): Promise<void> {
           data: {
             intentId: null,
             actor: userId,
+            agentId,
             event: 'AGENT_UNLINKED',
             payload: { agentId, cancelledIntentIds },
           },

--- a/src/contracts/audit.ts
+++ b/src/contracts/audit.ts
@@ -2,6 +2,7 @@ export interface AuditEventData {
   id: string;
   intentId: string | null;
   actor: string;
+  agentId: string | null;
   event: string;
   payload: Record<string, unknown>;
   createdAt: Date;

--- a/src/orchestrator/intentService.ts
+++ b/src/orchestrator/intentService.ts
@@ -166,13 +166,7 @@ export async function failCheckout(
   agentId: string | null = null,
 ): Promise<TransitionResult> {
   const actor = agentId ?? 'system';
-  return transitionIntent(
-    intentId,
-    IntentEvent.CHECKOUT_FAILED,
-    { errorMessage },
-    actor,
-    agentId,
-  );
+  return transitionIntent(intentId, IntentEvent.CHECKOUT_FAILED, { errorMessage }, actor, agentId);
 }
 
 async function cleanupExpiredIntent(intentId: string): Promise<void> {

--- a/src/orchestrator/intentService.ts
+++ b/src/orchestrator/intentService.ts
@@ -34,17 +34,24 @@ export async function startSearching(intentId: string): Promise<TransitionResult
 export async function receiveQuote(
   intentId: string,
   quotePayload: Record<string, unknown>,
+  agentId: string | null = null,
 ): Promise<TransitionResult> {
   // Persist quote data in metadata so the approval route can read merchant/price info
   await prisma.purchaseIntent.update({
     where: { id: intentId },
     data: { metadata: quotePayload as any },
   });
-  return transitionIntent(intentId, IntentEvent.QUOTE_RECEIVED, quotePayload);
+  // When an agent quotes, attribute the audit event to the agent.
+  const actor = agentId ?? 'system';
+  return transitionIntent(intentId, IntentEvent.QUOTE_RECEIVED, quotePayload, actor, agentId);
 }
 
-export async function requestApproval(intentId: string): Promise<TransitionResult> {
-  return transitionIntent(intentId, IntentEvent.APPROVAL_REQUESTED);
+export async function requestApproval(
+  intentId: string,
+  agentId: string | null = null,
+): Promise<TransitionResult> {
+  const actor = agentId ?? 'system';
+  return transitionIntent(intentId, IntentEvent.APPROVAL_REQUESTED, {}, actor, agentId);
 }
 
 export async function approveIntent(intentId: string, actorId: string): Promise<TransitionResult> {
@@ -63,15 +70,27 @@ export async function markCardIssued(intentId: string): Promise<TransitionResult
   return transitionIntent(intentId, IntentEvent.CARD_ISSUED);
 }
 
-export async function startCheckout(intentId: string): Promise<TransitionResult> {
-  return transitionIntent(intentId, IntentEvent.CHECKOUT_STARTED, {}, 'worker');
+export async function startCheckout(
+  intentId: string,
+  agentId: string | null = null,
+): Promise<TransitionResult> {
+  const actor = agentId ?? 'worker';
+  return transitionIntent(intentId, IntentEvent.CHECKOUT_STARTED, {}, actor, agentId);
 }
 
 export async function completeCheckout(
   intentId: string,
   actualAmount: number,
+  agentId: string | null = null,
 ): Promise<TransitionResult> {
-  const result = await transitionIntent(intentId, IntentEvent.CHECKOUT_SUCCEEDED, { actualAmount });
+  const actor = agentId ?? 'system';
+  const result = await transitionIntent(
+    intentId,
+    IntentEvent.CHECKOUT_SUCCEEDED,
+    { actualAmount },
+    actor,
+    agentId,
+  );
 
   // Apply cancel policy — fire-and-forget so policy errors never block the checkout response
   applyPostCheckoutCancelPolicy(intentId).catch((err) => {
@@ -144,8 +163,16 @@ async function notifyManualCardPending(
 export async function failCheckout(
   intentId: string,
   errorMessage: string,
+  agentId: string | null = null,
 ): Promise<TransitionResult> {
-  return transitionIntent(intentId, IntentEvent.CHECKOUT_FAILED, { errorMessage });
+  const actor = agentId ?? 'system';
+  return transitionIntent(
+    intentId,
+    IntentEvent.CHECKOUT_FAILED,
+    { errorMessage },
+    actor,
+    agentId,
+  );
 }
 
 async function cleanupExpiredIntent(intentId: string): Promise<void> {

--- a/src/orchestrator/stateMachine.ts
+++ b/src/orchestrator/stateMachine.ts
@@ -40,10 +40,7 @@ export async function transitionIntent(
       },
     });
 
-    log.info(
-      { intentId, event, previousStatus, newStatus, actor, agentId },
-      'Intent transition',
-    );
+    log.info({ intentId, event, previousStatus, newStatus, actor, agentId }, 'Intent transition');
 
     return {
       intent: updated as unknown as PurchaseIntentData,

--- a/src/orchestrator/stateMachine.ts
+++ b/src/orchestrator/stateMachine.ts
@@ -16,6 +16,7 @@ export async function transitionIntent(
   event: IntentEvent,
   payload: Record<string, unknown> = {},
   actor: string = 'system',
+  agentId: string | null = null,
 ): Promise<TransitionResult> {
   return await prisma.$transaction(async (tx) => {
     const intent = await tx.purchaseIntent.findUnique({ where: { id: intentId } });
@@ -33,12 +34,16 @@ export async function transitionIntent(
       data: {
         intentId,
         actor,
+        agentId,
         event,
         payload: { previousStatus, newStatus, ...payload } as any,
       },
     });
 
-    log.info({ intentId, event, previousStatus, newStatus, actor }, 'Intent transition');
+    log.info(
+      { intentId, event, previousStatus, newStatus, actor, agentId },
+      'Intent transition',
+    );
 
     return {
       intent: updated as unknown as PurchaseIntentData,

--- a/src/telegram/signupHandler.ts
+++ b/src/telegram/signupHandler.ts
@@ -162,6 +162,7 @@ export async function handleTelegramMessage(update: Update): Promise<void> {
         data: {
           intentId: null,
           actor: user.id,
+          agentId: session.agentId,
           event: 'AGENT_LINKED',
           payload: { agentId: session.agentId, telegramChatId: chatId.toString() },
         },

--- a/tests/unit/api/wiring.test.ts
+++ b/tests/unit/api/wiring.test.ts
@@ -359,8 +359,38 @@ describe('POST /v1/agent/quote wiring', () => {
         merchantUrl: 'https://amazon.co.uk',
         price: 9999,
       }),
+      null,
     );
-    expect(mockRequestApproval).toHaveBeenCalledWith('intent-q1');
+    expect(mockRequestApproval).toHaveBeenCalledWith('intent-q1', null);
+  });
+
+  it('propagates X-Agent-Id header into orchestrator calls', async () => {
+    seedSearchingIntent('intent-qAgent');
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/agent/quote',
+      headers: {
+        'content-type': 'application/json',
+        'x-worker-key': 'test-worker-key',
+        'x-agent-id': 'ag_test_123',
+      },
+      body: JSON.stringify({
+        intentId: 'intent-qAgent',
+        merchantName: 'Amazon UK',
+        merchantUrl: 'https://amazon.co.uk',
+        price: 4200,
+        currency: 'gbp',
+      }),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockReceiveQuote).toHaveBeenCalledWith(
+      'intent-qAgent',
+      expect.any(Object),
+      'ag_test_123',
+    );
+    expect(mockRequestApproval).toHaveBeenCalledWith('intent-qAgent', 'ag_test_123');
   });
 
   it('does NOT call receiveQuote for non-SEARCHING intent', async () => {
@@ -686,7 +716,7 @@ describe('POST /v1/agent/result wiring — success', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(mockCompleteCheckout).toHaveBeenCalledWith('intent-r1', 8000);
+    expect(mockCompleteCheckout).toHaveBeenCalledWith('intent-r1', 8000, null);
     expect(mockSettleIntent).toHaveBeenCalledWith('intent-r1', 8000);
     expect(mockFailCheckout).not.toHaveBeenCalled();
     expect(mockReturnIntent).not.toHaveBeenCalled();
@@ -739,7 +769,7 @@ describe('POST /v1/agent/result wiring — failure', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(mockFailCheckout).toHaveBeenCalledWith('intent-f1', 'Payment declined');
+    expect(mockFailCheckout).toHaveBeenCalledWith('intent-f1', 'Payment declined', null);
     expect(mockReturnIntent).toHaveBeenCalledWith('intent-f1');
     expect(mockCompleteCheckout).not.toHaveBeenCalled();
     expect(mockSettleIntent).not.toHaveBeenCalled();

--- a/tests/unit/orchestrator/actorAttribution.test.ts
+++ b/tests/unit/orchestrator/actorAttribution.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Actor-attribution tests for transitionIntent + intentService helpers.
+ *
+ * Guarantees:
+ *  - When an agentId is passed, the AuditEvent row records both actor=agentId
+ *    and agentId=<agentId>, and the log line carries { actor, agentId }.
+ *  - When no agentId is passed, AuditEvent.actor falls back to the documented
+ *    default for that helper ("system" / "worker") and agentId is null.
+ */
+
+jest.mock('@/db/client', () => ({
+  prisma: {
+    $transaction: jest.fn(),
+    purchaseIntent: { findUnique: jest.fn(), update: jest.fn() },
+    auditEvent: { create: jest.fn() },
+  },
+}));
+
+import { IntentStatus, IntentEvent } from '@/contracts';
+import { transitionIntent } from '@/orchestrator/stateMachine';
+import {
+  receiveQuote,
+  requestApproval,
+  startCheckout,
+  completeCheckout,
+  failCheckout,
+} from '@/orchestrator/intentService';
+import { prisma } from '@/db/client';
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+
+function setupTxMock(initialStatus: IntentStatus) {
+  const auditCreate = jest.fn().mockResolvedValue({});
+  const txIntentUpdate = jest.fn().mockImplementation(async ({ data }: any) => ({
+    id: 'intent-1',
+    status: data.status,
+  }));
+
+  (mockPrisma.$transaction as jest.Mock).mockImplementation(async (fn: Function) => {
+    const txMock = {
+      purchaseIntent: {
+        findUnique: jest.fn().mockResolvedValue({ id: 'intent-1', status: initialStatus }),
+        update: txIntentUpdate,
+      },
+      auditEvent: { create: auditCreate },
+    };
+    return fn(txMock);
+  });
+
+  return { auditCreate };
+}
+
+describe('AuditEvent actor attribution', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('transitionIntent', () => {
+    it('records actor=agentId and agentId=<agentId> when an agent triggers the transition', async () => {
+      const { auditCreate } = setupTxMock(IntentStatus.RECEIVED);
+      await transitionIntent(
+        'intent-1',
+        IntentEvent.INTENT_CREATED,
+        {},
+        'ag_abc123',
+        'ag_abc123',
+      );
+
+      expect(auditCreate).toHaveBeenCalledTimes(1);
+      const row = auditCreate.mock.calls[0][0].data;
+      expect(row.actor).toBe('ag_abc123');
+      expect(row.agentId).toBe('ag_abc123');
+      expect(row.event).toBe(IntentEvent.INTENT_CREATED);
+    });
+
+    it('defaults actor to "system" and agentId to null when neither is provided', async () => {
+      const { auditCreate } = setupTxMock(IntentStatus.RECEIVED);
+      await transitionIntent('intent-1', IntentEvent.INTENT_CREATED);
+
+      const row = auditCreate.mock.calls[0][0].data;
+      expect(row.actor).toBe('system');
+      expect(row.agentId).toBeNull();
+    });
+  });
+
+  describe('intentService helpers', () => {
+    it('receiveQuote: agentId attributed to both actor and agentId', async () => {
+      const { auditCreate } = setupTxMock(IntentStatus.SEARCHING);
+      (mockPrisma.purchaseIntent.update as jest.Mock).mockResolvedValue({
+        id: 'intent-1',
+        status: IntentStatus.SEARCHING,
+      });
+
+      await receiveQuote('intent-1', { price: 100 }, 'ag_quote');
+
+      const row = auditCreate.mock.calls[0][0].data;
+      expect(row.actor).toBe('ag_quote');
+      expect(row.agentId).toBe('ag_quote');
+    });
+
+    it('receiveQuote without agentId falls back to actor=system, agentId=null', async () => {
+      const { auditCreate } = setupTxMock(IntentStatus.SEARCHING);
+      (mockPrisma.purchaseIntent.update as jest.Mock).mockResolvedValue({
+        id: 'intent-1',
+        status: IntentStatus.SEARCHING,
+      });
+
+      await receiveQuote('intent-1', { price: 100 });
+
+      const row = auditCreate.mock.calls[0][0].data;
+      expect(row.actor).toBe('system');
+      expect(row.agentId).toBeNull();
+    });
+
+    it('requestApproval attributes the agent when provided', async () => {
+      const { auditCreate } = setupTxMock(IntentStatus.QUOTED);
+      await requestApproval('intent-1', 'ag_approve');
+
+      const row = auditCreate.mock.calls[0][0].data;
+      expect(row.actor).toBe('ag_approve');
+      expect(row.agentId).toBe('ag_approve');
+    });
+
+    it('startCheckout falls back to actor="worker" when no agentId is supplied', async () => {
+      const { auditCreate } = setupTxMock(IntentStatus.CARD_ISSUED);
+      await startCheckout('intent-1');
+
+      const row = auditCreate.mock.calls[0][0].data;
+      expect(row.actor).toBe('worker');
+      expect(row.agentId).toBeNull();
+    });
+
+    it('startCheckout uses the agentId when provided', async () => {
+      const { auditCreate } = setupTxMock(IntentStatus.CARD_ISSUED);
+      await startCheckout('intent-1', 'ag_checkout');
+
+      const row = auditCreate.mock.calls[0][0].data;
+      expect(row.actor).toBe('ag_checkout');
+      expect(row.agentId).toBe('ag_checkout');
+    });
+
+    it('completeCheckout attributes the agent and records actualAmount', async () => {
+      const { auditCreate } = setupTxMock(IntentStatus.CHECKOUT_RUNNING);
+      await completeCheckout('intent-1', 4200, 'ag_done');
+
+      const row = auditCreate.mock.calls[0][0].data;
+      expect(row.actor).toBe('ag_done');
+      expect(row.agentId).toBe('ag_done');
+      expect(row.payload.actualAmount).toBe(4200);
+    });
+
+    it('failCheckout attributes the agent and records errorMessage', async () => {
+      const { auditCreate } = setupTxMock(IntentStatus.CHECKOUT_RUNNING);
+      await failCheckout('intent-1', 'card declined', 'ag_fail');
+
+      const row = auditCreate.mock.calls[0][0].data;
+      expect(row.actor).toBe('ag_fail');
+      expect(row.agentId).toBe('ag_fail');
+      expect(row.payload.errorMessage).toBe('card declined');
+    });
+  });
+});

--- a/tests/unit/orchestrator/actorAttribution.test.ts
+++ b/tests/unit/orchestrator/actorAttribution.test.ts
@@ -56,13 +56,7 @@ describe('AuditEvent actor attribution', () => {
   describe('transitionIntent', () => {
     it('records actor=agentId and agentId=<agentId> when an agent triggers the transition', async () => {
       const { auditCreate } = setupTxMock(IntentStatus.RECEIVED);
-      await transitionIntent(
-        'intent-1',
-        IntentEvent.INTENT_CREATED,
-        {},
-        'ag_abc123',
-        'ag_abc123',
-      );
+      await transitionIntent('intent-1', IntentEvent.INTENT_CREATED, {}, 'ag_abc123', 'ag_abc123');
 
       expect(auditCreate).toHaveBeenCalledTimes(1);
       const row = auditCreate.mock.calls[0][0].data;


### PR DESCRIPTION
## Summary

Closes #17.

Gives every agent-origin action a first-class `agentId` on the audit trail and on structured log lines so multiple agents can be told apart.

- Prisma schema + migration: new nullable `agentId` column on `AuditEvent` with a `(intentId, agentId)` index.
- `transitionIntent(intentId, event, payload, actor, agentId?)` persists the column and adds it to the transition log line.
- `intentService` helpers (`receiveQuote`, `requestApproval`, `startCheckout`, `completeCheckout`, `failCheckout`) thread the agentId through. When an agent originated the call, `actor` is set to the agentId (per the issue description); otherwise `actor` keeps its documented default (`system` / `worker`).
- New `agentContextMiddleware` (registered as an `onRequest` hook on the agent plugin) reads `X-Agent-Id`, exposes `request.agentId`, rebinds `request.log` to a child logger with `{ agentId, intentId?, route }`, and emits an "Agent request received" log line so the context is always persisted to the structured log stream.
- `/v1/debug/audit/:intentId` now returns `agentId` per event (it is a column; Prisma returns it automatically).
- `AGENT_LINKED` (Telegram signup) and `AGENT_UNLINKED` (user unlink) rows now populate `agentId` explicitly.

## Test plan

- [x] `npm test` — 365 unit tests pass (9 new in `tests/unit/orchestrator/actorAttribution.test.ts`, plus an X-Agent-Id propagation case in `tests/unit/api/wiring.test.ts`).
- [x] Manual smoke test against `npm run dev`:
  - `POST /v1/agent/quote` with `X-Agent-Id: ag_smoke_test_17` →
    ```json
    [{"event":"QUOTE_RECEIVED","actor":"ag_smoke_test_17","agentId":"ag_smoke_test_17"},
     {"event":"APPROVAL_REQUESTED","actor":"ag_smoke_test_17","agentId":"ag_smoke_test_17"}]
    ```
  - Server log: `"route":"/v1/agent/quote","agentId":"ag_test_abc","msg":"Agent request received"`
  - `GET /v1/agent/decision/:intentId` log line: `"route":"/v1/agent/decision/:intentId","agentId":"ag_test_decision","intentId":"int_smoke17"`
- [x] `npx prisma migrate deploy` applies the new migration cleanly.

## Acceptance checklist (from the issue)

- [x] `AuditEvent.actor` for agent-triggered events contains the agentId.
- [x] `GET /v1/debug/audit/:intentId` returns `agentId` per event.
- [x] Structured log lines on agent routes include `{ agentId, intentId, route }`.
- [x] Schema migration adds nullable `agentId` to `AuditEvent`.
- [x] Unit test for actor attribution logic.