### PR TITLE
fix(issue-89): close AFTER_TTL cancel policy loopholes

### DIFF
--- a/src/orchestrator/intentService.ts
+++ b/src/orchestrator/intentService.ts
@@ -1,14 +1,13 @@
 import { prisma } from '@/db/client';
 import { IntentEvent, PurchaseIntentData, AuditEventData, IntentNotFoundError } from '@/contracts';
 import { logger } from '@/config/logger';
-
-const log = logger.child({ module: 'orchestrator/intentService' });
 import { transitionIntent, TransitionResult } from './stateMachine';
 import { getPaymentProvider, getProviderForIntent } from '@/payments';
 import { returnIntent } from '@/ledger/potService';
 import { enqueueCancelCard } from '@/queue/producers';
-import { getTelegramBot } from '@/telegram/telegramClient';
-import { InlineKeyboard } from 'grammy';
+import { sendManualCardPendingNotice } from '@/telegram/notificationService';
+
+const log = logger.child({ module: 'orchestrator/intentService' });
 
 export async function getIntentWithHistory(intentId: string): Promise<{
   intent: PurchaseIntentData;
@@ -128,43 +127,28 @@ async function applyPostCheckoutCancelPolicy(intentId: string): Promise<void> {
     await provider.cancelCard(intentId).catch((err) => {
       log.error({ intentId, err }, 'IMMEDIATE card cancel failed');
     });
-  } else if (cancelPolicy === 'AFTER_TTL' && cardTtlMinutes != null) {
-    // cardTtlMinutes <= 0 means cancel immediately rather than enqueueing a
-    // 0-delay job (avoids a queue round-trip and a job that races the
-    // checkout response). Truthy check would treat 0 as "unset" and silently
-    // leave the card live.
-    if (cardTtlMinutes <= 0) {
-      await provider.cancelCard(intentId).catch((err) => {
-        log.error({ intentId, err }, 'AFTER_TTL immediate card cancel failed');
-      });
-    } else {
+  } else if (cancelPolicy === 'AFTER_TTL') {
+    if (cardTtlMinutes != null && cardTtlMinutes > 0) {
       await enqueueCancelCard(intentId, cardTtlMinutes * 60 * 1000);
+    } else {
+      // Invariant violation: AFTER_TTL requires a positive cardTtlMinutes.
+      // Rather than silently leave the card active, fail loud and fall back
+      // to IMMEDIATE cancellation so no card outlives checkout.
+      log.error(
+        { intentId, cancelPolicy, cardTtlMinutes },
+        'AFTER_TTL policy with missing/invalid cardTtlMinutes — falling back to IMMEDIATE cancel',
+      );
+      await provider.cancelCard(intentId).catch((err) => {
+        log.error({ intentId, err }, 'AFTER_TTL fallback IMMEDIATE cancel failed');
+      });
     }
   } else if (cancelPolicy === 'MANUAL') {
     await provider.freezeCard(intentId).catch((err) => {
       log.error({ intentId, err }, 'MANUAL card freeze failed');
     });
     if (telegramChatId) {
-      await notifyManualCardPending(telegramChatId, intentId, intent.subject ?? intent.query);
+      await sendManualCardPendingNotice(telegramChatId, intentId, intent.subject ?? intent.query);
     }
-  }
-}
-
-async function notifyManualCardPending(
-  telegramChatId: string,
-  intentId: string,
-  label: string,
-): Promise<void> {
-  try {
-    const bot = getTelegramBot();
-    const keyboard = new InlineKeyboard().text('Cancel Card Now', `menu_card_cancel:${intentId}`);
-    await bot.api.sendMessage(
-      Number(telegramChatId),
-      `Checkout complete for "${label}".\n\nYour virtual card is frozen. Tap below when you no longer need it.`,
-      { reply_markup: keyboard },
-    );
-  } catch (err) {
-    log.error({ intentId, err }, 'Failed to send MANUAL card notification');
   }
 }
 

--- a/src/telegram/menuHandler.ts
+++ b/src/telegram/menuHandler.ts
@@ -258,7 +258,16 @@ async function savePrefPolicy(
   userId: string,
   policy: CardCancelPolicy,
 ): Promise<void> {
-  await prisma.user.update({ where: { id: userId }, data: { cancelPolicy: policy } });
+  // Switching away from AFTER_TTL must clear any stale TTL so checkout cannot
+  // later silently skip cancellation due to a leftover cardTtlMinutes value.
+  // Mirror the invariant enforced by the API-level Zod schema.
+  await prisma.user.update({
+    where: { id: userId },
+    data: {
+      cancelPolicy: policy,
+      cardTtlMinutes: policy === CardCancelPolicy.AFTER_TTL ? undefined : null,
+    },
+  });
   const keyboard = new InlineKeyboard().text('⬅️ Back to Menu', 'menu_main:_');
   await editMenu(
     bot,

--- a/src/telegram/notificationService.ts
+++ b/src/telegram/notificationService.ts
@@ -5,6 +5,24 @@ import { logger } from '@/config/logger';
 
 const log = logger.child({ module: 'telegram/notificationService' });
 
+export async function sendManualCardPendingNotice(
+  telegramChatId: string,
+  intentId: string,
+  label: string,
+): Promise<void> {
+  try {
+    const bot = getTelegramBot();
+    const keyboard = new InlineKeyboard().text('Cancel Card Now', `menu_card_cancel:${intentId}`);
+    await bot.api.sendMessage(
+      Number(telegramChatId),
+      `Checkout complete for "${label}".\n\nYour virtual card is frozen. Tap below when you no longer need it.`,
+      { reply_markup: keyboard },
+    );
+  } catch (err) {
+    log.error({ intentId, err }, 'Failed to send MANUAL card notification');
+  }
+}
+
 export async function sendApprovalRequest(intentId: string): Promise<void> {
   const intent = await prisma.purchaseIntent.findUnique({
     where: { id: intentId },

--- a/src/worker/processors/cancelCardProcessor.ts
+++ b/src/worker/processors/cancelCardProcessor.ts
@@ -1,6 +1,7 @@
-import { Worker, Job } from 'bullmq';
+import { Worker, Job, UnrecoverableError } from 'bullmq';
 import { getRedisConnectionConfig } from '@/config/redis';
 import { getProviderForIntent } from '@/payments';
+import { IntentNotFoundError } from '@/contracts';
 import { logger } from '@/config/logger';
 
 const log = logger.child({ module: 'worker/processors/cancelCardProcessor' });
@@ -9,18 +10,71 @@ interface CancelCardJob {
   intentId: string;
 }
 
+/**
+ * Pure job handler — exported so unit tests can drive it without standing up
+ * a real BullMQ Worker (which would require Redis). Keeping this separate from
+ * the Worker factory also means the retry / failure semantics are explicit
+ * and easy to reason about.
+ */
+export async function handleCancelCardJob(job: Job<CancelCardJob>): Promise<void> {
+  const { intentId } = job.data;
+  log.info({ intentId, attempt: job.attemptsMade + 1 }, 'Processing cancel card job');
+
+  try {
+    const provider = await getProviderForIntent(intentId);
+    await provider.cancelCard(intentId);
+    log.info({ intentId }, 'Card cancelled via AFTER_TTL policy');
+  } catch (err) {
+    // If the intent no longer exists (already cancelled, manually cleaned up,
+    // etc.) further retries cannot succeed. Mark the job unrecoverable so
+    // BullMQ stops retrying instead of burning through all attempts.
+    if (err instanceof IntentNotFoundError) {
+      log.warn({ intentId, err }, 'Cancel card job: intent not found — marking unrecoverable');
+      throw new UnrecoverableError(`Intent ${intentId} not found during AFTER_TTL cancel`);
+    }
+
+    // All other failures (Stripe 5xx, DB unreachable, …) are retried using
+    // the queue's configured exponential backoff. Log with full context so
+    // on-call engineers can diagnose.
+    log.error(
+      { intentId, attempt: job.attemptsMade + 1, err },
+      'Cancel card job failed — BullMQ will retry',
+    );
+    throw err;
+  }
+}
+
 export function createCancelCardWorker(): Worker {
-  return new Worker(
-    'cancel-card-queue',
-    async (job: Job<CancelCardJob>) => {
-      const { intentId } = job.data;
-      log.info({ intentId }, 'Processing cancel card job');
+  const worker = new Worker<CancelCardJob>('cancel-card-queue', handleCancelCardJob, {
+    connection: getRedisConnectionConfig(),
+    concurrency: 10,
+  });
 
-      const provider = await getProviderForIntent(intentId);
-      await provider.cancelCard(intentId);
+  worker.on('failed', (job, err) => {
+    if (!job) {
+      log.error({ err }, 'Cancel card job failed without job context');
+      return;
+    }
+    const exhausted = job.attemptsMade >= (job.opts.attempts ?? 1);
+    // A permanently-live virtual card is a real money leak — escalate loudly
+    // when all retries are exhausted so operators can intervene manually.
+    log.error(
+      {
+        intentId: job.data.intentId,
+        attemptsMade: job.attemptsMade,
+        maxAttempts: job.opts.attempts,
+        exhausted,
+        err,
+      },
+      exhausted
+        ? 'Cancel card job exhausted retries — card may remain active, manual intervention required'
+        : 'Cancel card job attempt failed',
+    );
+  });
 
-      log.info({ intentId }, 'Card cancelled via AFTER_TTL policy');
-    },
-    { connection: getRedisConnectionConfig(), concurrency: 10 },
-  );
+  worker.on('error', (err) => {
+    log.error({ err }, 'Cancel card worker error');
+  });
+
+  return worker;
 }

--- a/tests/unit/orchestrator/cancelPolicy.test.ts
+++ b/tests/unit/orchestrator/cancelPolicy.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit tests for the post-checkout cancel policy branch in
+ * `src/orchestrator/intentService.ts`.
+ *
+ * These cover regressions from issue #89:
+ *   - AFTER_TTL with a valid cardTtlMinutes enqueues a delayed cancel job
+ *   - AFTER_TTL with null/0/negative cardTtlMinutes must NOT silently no-op;
+ *     it must fall back to IMMEDIATE cancellation and log an error so the
+ *     card never remains live after checkout
+ *   - IMMEDIATE cancels synchronously
+ *   - MANUAL freezes and notifies via the telegram module (no direct UI
+ *     imports in orchestrator)
+ */
+
+jest.mock('@/db/client', () => ({
+  prisma: {
+    purchaseIntent: { findUnique: jest.fn(), update: jest.fn() },
+    auditEvent: { create: jest.fn() },
+    $transaction: jest.fn(),
+  },
+}));
+
+const mockCancelCard = jest.fn();
+const mockFreezeCard = jest.fn();
+jest.mock('@/payments', () => ({
+  getPaymentProvider: jest.fn(() => ({ cancelCard: mockCancelCard, freezeCard: mockFreezeCard })),
+}));
+
+const mockEnqueueCancelCard = jest.fn();
+jest.mock('@/queue/producers', () => ({
+  enqueueCancelCard: (...args: unknown[]) => mockEnqueueCancelCard(...args),
+  enqueueSearch: jest.fn(),
+  enqueueCheckout: jest.fn(),
+}));
+
+const mockSendManualCardPendingNotice = jest.fn();
+jest.mock('@/telegram/notificationService', () => ({
+  sendManualCardPendingNotice: (...args: unknown[]) => mockSendManualCardPendingNotice(...args),
+  sendApprovalRequest: jest.fn(),
+}));
+
+// Silence state-machine transitionIntent — we only care about the
+// fire-and-forget cancel policy side effect invoked by completeCheckout.
+jest.mock('@/orchestrator/stateMachine', () => ({
+  transitionIntent: jest.fn().mockResolvedValue({
+    previousStatus: 'CHECKOUT_RUNNING',
+    newStatus: 'DONE',
+    intent: {},
+  }),
+}));
+
+import { completeCheckout } from '@/orchestrator/intentService';
+import { prisma } from '@/db/client';
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+
+function mockIntent(
+  cancelPolicy: string,
+  cardTtlMinutes: number | null,
+  overrides: {
+    telegramChatId?: string | null;
+    hasVirtualCard?: boolean;
+    subject?: string | null;
+  } = {},
+) {
+  const telegramChatId =
+    'telegramChatId' in overrides ? (overrides.telegramChatId ?? null) : '1234';
+  (mockPrisma.purchaseIntent.findUnique as jest.Mock).mockResolvedValue({
+    id: 'intent-1',
+    subject: overrides.subject ?? 'headphones',
+    query: 'headphones',
+    user: {
+      cancelPolicy,
+      cardTtlMinutes,
+      telegramChatId,
+      paymentProvider: 'STRIPE',
+    },
+    virtualCard: overrides.hasVirtualCard === false ? null : { id: 'vc-1' },
+  });
+}
+
+// completeCheckout triggers applyPostCheckoutCancelPolicy via a fire-and-forget
+// .catch chain — yield to the next event-loop turn so pending awaits settle.
+async function flushAsync() {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCancelCard.mockResolvedValue(undefined);
+  mockFreezeCard.mockResolvedValue(undefined);
+  mockEnqueueCancelCard.mockResolvedValue(undefined);
+  mockSendManualCardPendingNotice.mockResolvedValue(undefined);
+});
+
+afterAll(() => {
+  errorSpy.mockRestore();
+});
+
+describe('applyPostCheckoutCancelPolicy via completeCheckout', () => {
+  it('AFTER_TTL with a positive cardTtlMinutes enqueues a delayed cancel job', async () => {
+    mockIntent('AFTER_TTL', 60);
+    await completeCheckout('intent-1', 5000);
+    await flushAsync();
+
+    expect(mockEnqueueCancelCard).toHaveBeenCalledWith('intent-1', 60 * 60 * 1000);
+    expect(mockCancelCard).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['null', null],
+    ['zero', 0],
+    ['negative', -5],
+  ])(
+    'AFTER_TTL with %s cardTtlMinutes falls back to IMMEDIATE cancel (no silent no-op)',
+    async (_label, ttl) => {
+      mockIntent('AFTER_TTL', ttl);
+      await completeCheckout('intent-1', 5000);
+      await flushAsync();
+
+      // Regression (issue #89, bug 2): the cancel job must not be skipped.
+      expect(mockEnqueueCancelCard).not.toHaveBeenCalled();
+      expect(mockCancelCard).toHaveBeenCalledWith('intent-1');
+    },
+  );
+
+  it('IMMEDIATE policy cancels card synchronously', async () => {
+    mockIntent('IMMEDIATE', null);
+    await completeCheckout('intent-1', 5000);
+    await flushAsync();
+
+    expect(mockCancelCard).toHaveBeenCalledWith('intent-1');
+    expect(mockEnqueueCancelCard).not.toHaveBeenCalled();
+  });
+
+  it('MANUAL policy freezes card and notifies via telegram module (no UI in orchestrator)', async () => {
+    mockIntent('MANUAL', null, { telegramChatId: '98765', subject: 'coffee' });
+    await completeCheckout('intent-1', 5000);
+    await flushAsync();
+
+    expect(mockFreezeCard).toHaveBeenCalledWith('intent-1');
+    // Regression (issue #89, bug 4): orchestrator must delegate the user
+    // notification to the telegram module rather than import grammy directly.
+    expect(mockSendManualCardPendingNotice).toHaveBeenCalledWith('98765', 'intent-1', 'coffee');
+  });
+
+  it('MANUAL policy without telegramChatId still freezes the card', async () => {
+    mockIntent('MANUAL', null, { telegramChatId: null });
+    await completeCheckout('intent-1', 5000);
+    await flushAsync();
+
+    expect(mockFreezeCard).toHaveBeenCalledWith('intent-1');
+    expect(mockSendManualCardPendingNotice).not.toHaveBeenCalled();
+  });
+
+  it('ON_TRANSACTION policy with an existing virtual card defers to Stripe webhook', async () => {
+    mockIntent('ON_TRANSACTION', null, { hasVirtualCard: true });
+    await completeCheckout('intent-1', 5000);
+    await flushAsync();
+
+    expect(mockCancelCard).not.toHaveBeenCalled();
+    expect(mockEnqueueCancelCard).not.toHaveBeenCalled();
+  });
+
+  it('ON_TRANSACTION policy without a virtual card cancels as stub fallback', async () => {
+    mockIntent('ON_TRANSACTION', null, { hasVirtualCard: false });
+    await completeCheckout('intent-1', 5000);
+    await flushAsync();
+
+    expect(mockCancelCard).toHaveBeenCalledWith('intent-1');
+  });
+});

--- a/tests/unit/orchestrator/postCheckoutCancelPolicy.test.ts
+++ b/tests/unit/orchestrator/postCheckoutCancelPolicy.test.ts
@@ -102,7 +102,7 @@ describe('completeCheckout — AFTER_TTL cancel policy', () => {
     expect(mockCancelCard).not.toHaveBeenCalled();
   });
 
-  it('does nothing when cardTtlMinutes is null even with AFTER_TTL policy', async () => {
+  it('falls back to immediate cancel when cardTtlMinutes is null under AFTER_TTL', async () => {
     (mockPrisma.purchaseIntent.findUnique as jest.Mock).mockResolvedValue(
       intentWithUser({ cancelPolicy: 'AFTER_TTL', cardTtlMinutes: null }),
     );
@@ -110,7 +110,7 @@ describe('completeCheckout — AFTER_TTL cancel policy', () => {
     await completeCheckout('intent-1', 1000);
     await flush();
 
-    expect(mockCancelCard).not.toHaveBeenCalled();
+    expect(mockCancelCard).toHaveBeenCalledWith('intent-1');
     expect(mockEnqueueCancelCard).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/telegram/menuHandler.test.ts
+++ b/tests/unit/telegram/menuHandler.test.ts
@@ -421,7 +421,7 @@ describe('menu_preferences', () => {
 // ── menu_pref_policy ─────────────────────────────────────────────────────────
 
 describe('menu_pref_policy', () => {
-  it('saves IMMEDIATE policy and shows confirmation', async () => {
+  it('saves IMMEDIATE policy, clears stale cardTtlMinutes, and shows confirmation', async () => {
     (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);
 
     await handleMenuCallback(
@@ -433,14 +433,42 @@ describe('menu_pref_policy', () => {
       fromId,
     );
 
+    // Regression (issue #89, bug 1): switching away from AFTER_TTL must clear
+    // cardTtlMinutes so a stale TTL cannot silently skip cancellation later.
     expect(mockPrisma.user.update).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: { cancelPolicy: 'IMMEDIATE' },
+        data: { cancelPolicy: 'IMMEDIATE', cardTtlMinutes: null },
       }),
     );
     const text = mockEditMessageText.mock.calls[0][2] as string;
     expect(text.toLowerCase()).toContain('saved');
   });
+
+  it.each(['ON_TRANSACTION', 'MANUAL'] as const)(
+    'clears stale cardTtlMinutes when switching to %s',
+    async (policy) => {
+      (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue({
+        ...baseUser,
+        cancelPolicy: 'AFTER_TTL',
+        cardTtlMinutes: 240,
+      });
+
+      await handleMenuCallback(
+        { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+        chatId,
+        messageId,
+        'menu_pref_policy',
+        policy,
+        fromId,
+      );
+
+      expect(mockPrisma.user.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { cancelPolicy: policy, cardTtlMinutes: null },
+        }),
+      );
+    },
+  );
 
   it('shows TTL picker when AFTER_TTL is selected', async () => {
     (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);

--- a/tests/unit/worker/cancelCardProcessor.test.ts
+++ b/tests/unit/worker/cancelCardProcessor.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Unit tests for the AFTER_TTL cancel card job handler.
+ *
+ * Regression tests for issue #89 bug 3: the processor previously had no
+ * try/catch, no logging, and no mechanism to stop retrying unrecoverable
+ * errors. A Stripe or DB failure would bubble silently while a
+ * dead-intent error would exhaust all retries.
+ */
+
+const mockCancelCard = jest.fn();
+jest.mock('@/payments', () => ({
+  getProviderForIntent: jest.fn().mockResolvedValue({ cancelCard: mockCancelCard }),
+}));
+
+// handleCancelCardJob imports IntentNotFoundError from @/contracts; no mock
+// needed — we use the real class.
+import { UnrecoverableError } from 'bullmq';
+import type { Job } from 'bullmq';
+import { IntentNotFoundError } from '@/contracts';
+import { handleCancelCardJob } from '@/worker/processors/cancelCardProcessor';
+
+function fakeJob(intentId: string, attemptsMade = 0): Job<{ intentId: string }> {
+  return { data: { intentId }, attemptsMade } as unknown as Job<{ intentId: string }>;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('handleCancelCardJob', () => {
+  it('calls payment provider cancelCard on happy path', async () => {
+    mockCancelCard.mockResolvedValue(undefined);
+
+    await expect(handleCancelCardJob(fakeJob('intent-1'))).resolves.toBeUndefined();
+
+    expect(mockCancelCard).toHaveBeenCalledWith('intent-1');
+  });
+
+  it('rethrows transient errors so BullMQ retries them', async () => {
+    const stripeError = new Error('Stripe 503 service unavailable');
+    mockCancelCard.mockRejectedValue(stripeError);
+
+    await expect(handleCancelCardJob(fakeJob('intent-1', 0))).rejects.toThrow(stripeError);
+  });
+
+  it('wraps IntentNotFoundError in UnrecoverableError to stop retries', async () => {
+    mockCancelCard.mockRejectedValue(new IntentNotFoundError('intent-42'));
+
+    await expect(handleCancelCardJob(fakeJob('intent-42'))).rejects.toBeInstanceOf(
+      UnrecoverableError,
+    );
+  });
+});


### PR DESCRIPTION
Closes #89.

## Summary

Four related bugs in the `AFTER_TTL` card-cancel policy could leave a virtual card permanently active in Stripe after checkout. This PR plugs all four and adds regression tests.

| # | Bug | Fix |
|---|-----|-----|
| 1 | `savePrefPolicy` left a stale `cardTtlMinutes` when switching away from `AFTER_TTL` (`src/telegram/menuHandler.ts:254`) | Clear `cardTtlMinutes` to `null` on every non-`AFTER_TTL` switch, mirroring the API-level Zod invariant. |
| 2 | `AFTER_TTL` + null / non-positive `cardTtlMinutes` silently skipped cancellation (`src/orchestrator/intentService.ts:131`) | Log at `error` level and fall back to **`IMMEDIATE`** cancellation so no card outlives checkout. |
| 3 | `cancelCardProcessor` had no `try/catch`, no structured logs, and no `failed` listener (`src/worker/processors/cancelCardProcessor.ts`) | Wrap Stripe/DB errors in structured logs, throw `UnrecoverableError` for `IntentNotFoundError` so BullMQ stops retrying a dead intent, and escalate loudly when retries are exhausted. |
| 4 | Orchestrator imported `getTelegramBot` + `InlineKeyboard` directly, violating the module boundary | Move `notifyManualCardPending` into `src/telegram/notificationService.ts` as `sendManualCardPendingNotice`; orchestrator now only calls the telegram module interface. |

## Testing

- `tests/unit/telegram/menuHandler.test.ts` — asserts `cardTtlMinutes` is cleared on every non-`AFTER_TTL` switch (parameterized over `ON_TRANSACTION`, `IMMEDIATE`, `MANUAL`).
- `tests/unit/orchestrator/cancelPolicy.test.ts` (new) — covers all four cancel policies, including the `null` / `0` / negative TTL fallback and the `MANUAL` notification being dispatched through the telegram module.
- `tests/unit/worker/cancelCardProcessor.test.ts` (new) — happy path, transient-error retry, and `IntentNotFoundError` → `UnrecoverableError` mapping.

Local results:
- ✅ **370 / 370 unit tests pass** (`jest --testPathPattern=unit`)
- ✅ `tsc --noEmit` clean
- ✅ `eslint` 0 errors (pre-existing warnings only)
- ✅ `prettier --check` clean
- ✅ `tests/integration/telegram/menuHandler.test.ts` passes end-to-end against real Postgres + Redis

## Review / feedback notes

A few design choices worth calling out:

1. **Fallback vs. fail-closed.** Bug 2 had two defensible fixes: fall back to `IMMEDIATE` cancel, or refuse the checkout with a DB `CHECK` constraint. I chose the fallback because checkout has already succeeded by the time we hit this branch — refusing the card cancel at that point does not undo the purchase, it only increases the window in which the card is live. A DB `CHECK(cancelPolicy != 'AFTER_TTL' OR cardTtlMinutes IS NOT NULL)` would be a good additional belt-and-braces defense in a follow-up migration.
2. **`UnrecoverableError` for missing intents.** Without this, the queue's 5 configured attempts with exponential backoff will burn all retries on an intent that will never exist again. Fail fast, keep the logs clean, free up worker capacity.
3. **Loud `failed` listener.** A permanently-live test card is a real money leak in production. The `exhausted` branch intentionally logs at `error` with `"manual intervention required"` so alerting can page on it.
4. **Module boundary.** Moving the notification out of the orchestrator keeps grammy/InlineKeyboard isolated to `src/telegram/`. If a second notification channel is added later (e.g. email, SMS) the orchestrator will not need to change.
5. **Testability.** The processor now exports `handleCancelCardJob` as a plain async function so unit tests can drive it without spinning up a real BullMQ Worker and Redis connection. The exported `createCancelCardWorker` is unchanged from the caller's perspective.

## Out of scope

- A DB-level `CHECK` constraint enforcing the `AFTER_TTL` ↔ `cardTtlMinutes` invariant (see point 1 above).
- Adding an `IPaymentProvider`-style interface for telegram notifications in `src/contracts/services.ts`. The current direct import respects the boundary rule and keeps the diff surgical; a formal contract can be extracted when a second channel appears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancel-policy handling to gracefully manage invalid or missing TTL values by canceling cards immediately instead of hanging.
  * Enhanced card-cancellation error handling with better retry logic for transient failures.
  * Fixed stale TTL state when switching between cancellation policies.

* **New Features**
  * Manual card pending notifications now centralized through shared Telegram service.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JonasBaeumer/AgentWallet/pull/136)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->