### PR TITLE
fix(issue-90): restore observability and input validation in Telegram menu

### DIFF
--- a/src/telegram/menuHandler.ts
+++ b/src/telegram/menuHandler.ts
@@ -316,7 +316,10 @@ async function savePrefPolicy(
   userId: string,
   policy: CardCancelPolicy,
 ): Promise<void> {
-  await prisma.user.update({ where: { id: userId }, data: { cancelPolicy: policy } });
+  await prisma.user.update({
+    where: { id: userId },
+    data: { cancelPolicy: policy, cardTtlMinutes: null },
+  });
   const keyboard = new InlineKeyboard().text('⬅️ Back to Menu', 'menu_main:_');
   await editMenu(
     bot,

--- a/src/telegram/menuHandler.ts
+++ b/src/telegram/menuHandler.ts
@@ -78,18 +78,17 @@ async function editMenu(
     });
   } catch (err) {
     if (isMessageNotModifiedError(err)) return;
-    log.error(
-      { chatId, messageId, err },
-      'Failed to edit Telegram menu message',
-    );
+    log.error({ chatId, messageId, err }, 'Failed to edit Telegram menu message');
     throw err;
   }
 }
 
-// Best-effort surface used by error paths. We've already logged the underlying
-// failure at the call site; if Telegram itself is unreachable here too, swallow
-// the secondary error so the handler can complete.
-async function editMenuSafe(
+// Fire-and-forget variant: never throws. Use this when the calling code has
+// already completed its irreversible work (e.g. cancel succeeded) and a
+// failure to render the confirmation must NOT be surfaced as if the work
+// itself had failed. `editMenu` already logs the underlying Telegram failure
+// before throwing, so we just swallow it here.
+async function tryEditMenu(
   bot: ReturnType<typeof getTelegramBot>,
   chatId: number | string,
   messageId: number,
@@ -98,11 +97,8 @@ async function editMenuSafe(
 ): Promise<void> {
   try {
     await editMenu(bot, chatId, messageId, text, keyboard);
-  } catch (err) {
-    log.error(
-      { chatId, messageId, err },
-      'Failed to surface error to user via Telegram',
-    );
+  } catch {
+    // Already logged inside editMenu; intentional swallow.
   }
 }
 
@@ -219,27 +215,33 @@ async function doCancelIntent(
   messageId: number,
   intentId: string,
 ): Promise<void> {
+  const keyboard = new InlineKeyboard().text('⬅️ Back', 'menu_main:_');
+
+  // The mutation and the confirmation edit are deliberately handled in
+  // separate try/catch blocks. If the cancel succeeds but Telegram fails to
+  // render the confirmation, we must NOT show "Something went wrong" — the
+  // user would be tempted to retry an already-cancelled intent.
   try {
     await expireIntent(intentId);
-    const keyboard = new InlineKeyboard().text('⬅️ Back', 'menu_main:_');
-    await editMenu(
-      bot,
-      chatId,
-      messageId,
-      '✅ Intent cancelled. Your budget has been returned.',
-      keyboard,
-    );
   } catch (err) {
-    log.error({ chatId, intentId, err }, 'doCancelIntent failed');
-    const keyboard = new InlineKeyboard().text('⬅️ Back', 'menu_main:_');
-    await editMenuSafe(
+    log.error({ chatId, intentId, err }, 'doCancelIntent: expireIntent failed');
+    await tryEditMenu(
       bot,
       chatId,
       messageId,
       '⚠️ Something went wrong. Please try again.',
       keyboard,
     );
+    return;
   }
+
+  await tryEditMenu(
+    bot,
+    chatId,
+    messageId,
+    '✅ Intent cancelled. Your budget has been returned.',
+    keyboard,
+  );
 }
 
 async function showAgentStatus(
@@ -376,22 +378,27 @@ async function doCancelCard(
   messageId: number,
   intentId: string,
 ): Promise<void> {
+  const keyboard = new InlineKeyboard().text('⬅️ Back to Menu', 'menu_main:_');
+
+  // Same split as doCancelIntent: a Telegram failure after the card is
+  // already cancelled must not be surfaced as "Something went wrong" — the
+  // user would retry a no-op cancel against an already-cancelled card.
   try {
     const provider = await getProviderForIntent(intentId);
     await provider.cancelCard(intentId);
-    const keyboard = new InlineKeyboard().text('⬅️ Back to Menu', 'menu_main:_');
-    await editMenu(bot, chatId, messageId, '✅ Card cancelled successfully.', keyboard);
   } catch (err) {
-    log.error({ chatId, intentId, err }, 'doCancelCard failed');
-    const keyboard = new InlineKeyboard().text('⬅️ Back to Menu', 'menu_main:_');
-    await editMenuSafe(
+    log.error({ chatId, intentId, err }, 'doCancelCard: cancelCard failed');
+    await tryEditMenu(
       bot,
       chatId,
       messageId,
       '⚠️ Something went wrong cancelling the card. Please try again.',
       keyboard,
     );
+    return;
   }
+
+  await tryEditMenu(bot, chatId, messageId, '✅ Card cancelled successfully.', keyboard);
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
@@ -424,47 +431,50 @@ export async function handleMenuCallback(
   payload: string,
   _fromTelegramId: number,
 ): Promise<void> {
-  // Actions that don't need a user record
-  if (action === 'menu_main') {
-    const keyboard = buildMainMenuKeyboard();
-    await editMenu(bot, chatId, messageId, '📱 <b>Main Menu</b>', keyboard);
-    return;
-  }
-
-  if (action === 'menu_cancel_confirm') {
-    await showCancelConfirm(bot, chatId, messageId, payload);
-    return;
-  }
-
-  if (action === 'menu_cancel_do') {
-    await doCancelIntent(bot, chatId, messageId, payload);
-    return;
-  }
-
-  if (action === 'menu_card_cancel') {
-    await doCancelCard(bot, chatId, messageId, payload);
-    return;
-  }
-
-  if (action === 'menu_pref_ttl' && payload === 'custom') {
-    await startCustomTtlInput(bot, chatId, messageId);
-    return;
-  }
-
-  // All remaining actions need a user record
-  const user = await getUserByChatId(chatId);
-
-  if (!user) {
-    await editMenu(
-      bot,
-      chatId,
-      messageId,
-      '⚠️ You need to sign up first. Send /start &lt;code&gt; to get started.',
-    );
-    return;
-  }
-
+  // The whole dispatch — including the user lookup — runs inside one recovery
+  // boundary so a DB failure on getUserByChatId is caught here too, not left
+  // to bubble up to the Telegram middleware with no user-facing feedback.
   try {
+    // Actions that don't need a user record
+    if (action === 'menu_main') {
+      const keyboard = buildMainMenuKeyboard();
+      await editMenu(bot, chatId, messageId, '📱 <b>Main Menu</b>', keyboard);
+      return;
+    }
+
+    if (action === 'menu_cancel_confirm') {
+      await showCancelConfirm(bot, chatId, messageId, payload);
+      return;
+    }
+
+    if (action === 'menu_cancel_do') {
+      await doCancelIntent(bot, chatId, messageId, payload);
+      return;
+    }
+
+    if (action === 'menu_card_cancel') {
+      await doCancelCard(bot, chatId, messageId, payload);
+      return;
+    }
+
+    if (action === 'menu_pref_ttl' && payload === 'custom') {
+      await startCustomTtlInput(bot, chatId, messageId);
+      return;
+    }
+
+    // All remaining actions need a user record
+    const user = await getUserByChatId(chatId);
+
+    if (!user) {
+      await editMenu(
+        bot,
+        chatId,
+        messageId,
+        '⚠️ You need to sign up first. Send /start &lt;code&gt; to get started.',
+      );
+      return;
+    }
+
     if (action === 'menu_balance') {
       await showBalance(bot, chatId, messageId, user);
     } else if (action === 'menu_history') {
@@ -499,11 +509,7 @@ export async function handleMenuCallback(
       // require the payload to be an integer string so e.g. "12.5" is not
       // silently truncated to 12 by parseInt.
       const minutes = /^[1-9]\d*$/.test(payload) ? Number.parseInt(payload, 10) : NaN;
-      if (
-        !Number.isInteger(minutes) ||
-        minutes < TTL_MIN_MINUTES ||
-        minutes > TTL_MAX_MINUTES
-      ) {
+      if (!Number.isInteger(minutes) || minutes < TTL_MIN_MINUTES || minutes > TTL_MAX_MINUTES) {
         log.warn(
           { chatId, action, payload, parsed: minutes },
           'Rejected out-of-range TTL value from Telegram callback',
@@ -523,15 +529,7 @@ export async function handleMenuCallback(
       log.warn({ chatId, action, payload }, 'Unknown menu_* callback action');
     }
   } catch (err) {
-    log.error(
-      { chatId, messageId, action, payload, userId: user.id, err },
-      'menu callback handler failed',
-    );
-    await editMenuSafe(
-      bot,
-      chatId,
-      messageId,
-      '⚠️ Something went wrong. Please try again.',
-    );
+    log.error({ chatId, messageId, action, payload, err }, 'menu callback handler failed');
+    await tryEditMenu(bot, chatId, messageId, '⚠️ Something went wrong. Please try again.');
   }
 }

--- a/src/telegram/menuHandler.ts
+++ b/src/telegram/menuHandler.ts
@@ -5,6 +5,15 @@ import { expireIntent } from '@/orchestrator/intentService';
 import { getProviderForIntent } from '@/payments';
 import { IntentStatus, CardCancelPolicy } from '@/contracts';
 import { setPrefSession } from './sessionStore';
+import { logger } from '@/config/logger';
+
+const log = logger.child({ module: 'telegram/menuHandler' });
+
+// Mirrors the API-level Zod bounds for cardTtlMinutes (src/api/routes/users.ts).
+// Telegram callback payloads can be forged, so the same range is enforced here
+// before any DB write.
+const TTL_MIN_MINUTES = 1;
+const TTL_MAX_MINUTES = 10080;
 
 const POLICY_LABELS: Record<CardCancelPolicy, string> = {
   [CardCancelPolicy.ON_TRANSACTION]: 'On Transaction',
@@ -12,6 +21,19 @@ const POLICY_LABELS: Record<CardCancelPolicy, string> = {
   [CardCancelPolicy.AFTER_TTL]: 'After TTL',
   [CardCancelPolicy.MANUAL]: 'Manual',
 };
+
+function isMessageNotModifiedError(err: unknown): boolean {
+  // grammy surfaces Telegram API errors with shape { error_code, description }.
+  // The 400 "message is not modified" response fires whenever editMessageText is
+  // called with text + markup identical to what is already shown — benign.
+  if (typeof err !== 'object' || err === null) return false;
+  const e = err as { error_code?: number; description?: unknown };
+  return (
+    e.error_code === 400 &&
+    typeof e.description === 'string' &&
+    e.description.includes('message is not modified')
+  );
+}
 
 const ACTIVE_INTENT_STATUSES: IntentStatus[] = [
   IntentStatus.RECEIVED,
@@ -49,12 +71,39 @@ async function editMenu(
   text: string,
   keyboard?: InlineKeyboard,
 ): Promise<void> {
-  await bot.api
-    .editMessageText(chatId, messageId, text, {
+  try {
+    await bot.api.editMessageText(chatId, messageId, text, {
       parse_mode: 'HTML',
       reply_markup: keyboard,
-    })
-    .catch(() => {});
+    });
+  } catch (err) {
+    if (isMessageNotModifiedError(err)) return;
+    log.error(
+      { chatId, messageId, err },
+      'Failed to edit Telegram menu message',
+    );
+    throw err;
+  }
+}
+
+// Best-effort surface used by error paths. We've already logged the underlying
+// failure at the call site; if Telegram itself is unreachable here too, swallow
+// the secondary error so the handler can complete.
+async function editMenuSafe(
+  bot: ReturnType<typeof getTelegramBot>,
+  chatId: number | string,
+  messageId: number,
+  text: string,
+  keyboard?: InlineKeyboard,
+): Promise<void> {
+  try {
+    await editMenu(bot, chatId, messageId, text, keyboard);
+  } catch (err) {
+    log.error(
+      { chatId, messageId, err },
+      'Failed to surface error to user via Telegram',
+    );
+  }
 }
 
 async function showBalance(
@@ -180,9 +229,16 @@ async function doCancelIntent(
       '✅ Intent cancelled. Your budget has been returned.',
       keyboard,
     );
-  } catch {
+  } catch (err) {
+    log.error({ chatId, intentId, err }, 'doCancelIntent failed');
     const keyboard = new InlineKeyboard().text('⬅️ Back', 'menu_main:_');
-    await editMenu(bot, chatId, messageId, '⚠️ Something went wrong. Please try again.', keyboard);
+    await editMenuSafe(
+      bot,
+      chatId,
+      messageId,
+      '⚠️ Something went wrong. Please try again.',
+      keyboard,
+    );
   }
 }
 
@@ -325,9 +381,10 @@ async function doCancelCard(
     await provider.cancelCard(intentId);
     const keyboard = new InlineKeyboard().text('⬅️ Back to Menu', 'menu_main:_');
     await editMenu(bot, chatId, messageId, '✅ Card cancelled successfully.', keyboard);
-  } catch {
+  } catch (err) {
+    log.error({ chatId, intentId, err }, 'doCancelCard failed');
     const keyboard = new InlineKeyboard().text('⬅️ Back to Menu', 'menu_main:_');
-    await editMenu(
+    await editMenuSafe(
       bot,
       chatId,
       messageId,
@@ -419,6 +476,16 @@ export async function handleMenuCallback(
     } else if (action === 'menu_preferences') {
       await showPreferences(bot, chatId, messageId, user);
     } else if (action === 'menu_pref_policy') {
+      // Callback payloads can be forged — validate against the enum before use.
+      const allowedPolicies = Object.values(CardCancelPolicy) as string[];
+      if (!allowedPolicies.includes(payload)) {
+        log.warn(
+          { chatId, action, payload },
+          'Rejected unknown cancel policy from Telegram callback',
+        );
+        await editMenu(bot, chatId, messageId, '⚠️ Invalid cancel policy.');
+        return;
+      }
       const policy = payload as CardCancelPolicy;
       if (policy === CardCancelPolicy.AFTER_TTL) {
         await showTtlPicker(bot, chatId, messageId);
@@ -426,11 +493,45 @@ export async function handleMenuCallback(
         await savePrefPolicy(bot, chatId, messageId, user.id, policy);
       }
     } else if (action === 'menu_pref_ttl') {
-      const minutes = parseInt(payload, 10);
+      // Mirror the API-level Zod validation so a forged callback (e.g.
+      // `menu_pref_ttl:-1`, `menu_pref_ttl:99999`, or `menu_pref_ttl:12.5`)
+      // cannot bypass the bounds by going through the Telegram path. We
+      // require the payload to be an integer string so e.g. "12.5" is not
+      // silently truncated to 12 by parseInt.
+      const minutes = /^[1-9]\d*$/.test(payload) ? Number.parseInt(payload, 10) : NaN;
+      if (
+        !Number.isInteger(minutes) ||
+        minutes < TTL_MIN_MINUTES ||
+        minutes > TTL_MAX_MINUTES
+      ) {
+        log.warn(
+          { chatId, action, payload, parsed: minutes },
+          'Rejected out-of-range TTL value from Telegram callback',
+        );
+        await editMenu(
+          bot,
+          chatId,
+          messageId,
+          `⚠️ Invalid TTL. Must be between ${TTL_MIN_MINUTES} and ${TTL_MAX_MINUTES} minutes.`,
+        );
+        return;
+      }
       await savePrefTtl(bot, chatId, messageId, user.id, minutes);
+    } else {
+      // Unknown menu_* actions: log so we notice if the UI ships a button the
+      // backend doesn't handle, but don't crash.
+      log.warn({ chatId, action, payload }, 'Unknown menu_* callback action');
     }
-    // Unknown menu_* actions: silently ignore (no crash)
-  } catch {
-    await editMenu(bot, chatId, messageId, '⚠️ Something went wrong. Please try again.');
+  } catch (err) {
+    log.error(
+      { chatId, messageId, action, payload, userId: user.id, err },
+      'menu callback handler failed',
+    );
+    await editMenuSafe(
+      bot,
+      chatId,
+      messageId,
+      '⚠️ Something went wrong. Please try again.',
+    );
   }
 }

--- a/tests/unit/telegram/menuHandler.test.ts
+++ b/tests/unit/telegram/menuHandler.test.ts
@@ -7,6 +7,18 @@ jest.mock('@/db/client', () => ({
   },
 }));
 
+// Mock logger so we can assert observability calls (issue #90 — the main
+// contract of these fixes is restored visibility, not just resolved promises).
+const mockChildLogger = {
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+};
+jest.mock('@/config/logger', () => ({
+  logger: { child: jest.fn(() => mockChildLogger) },
+}));
+
 // Mock Telegram bot
 const mockSendMessage = jest.fn().mockResolvedValue({ message_id: 99 });
 const mockEditMessageText = jest.fn().mockResolvedValue({});
@@ -74,6 +86,8 @@ beforeEach(() => {
   mockFreezeCard.mockResolvedValue(undefined);
   mockSetPrefSession.mockResolvedValue(undefined);
   (mockPrisma.user.update as jest.Mock).mockResolvedValue({});
+  mockChildLogger.error.mockClear();
+  mockChildLogger.warn.mockClear();
 });
 
 // ── sendMainMenu ──────────────────────────────────────────────────────────────
@@ -598,7 +612,7 @@ describe('unknown menu_ action', () => {
 // ── observability fixes (issue #90) ───────────────────────────────────────────
 
 describe('editMenu error handling (issue #90 bug 2)', () => {
-  it('swallows the benign "message is not modified" 400 error from Telegram', async () => {
+  it('swallows the benign "message is not modified" 400 error from Telegram without logging', async () => {
     (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);
     (mockPrisma.pot.findMany as jest.Mock).mockResolvedValue([]);
     mockEditMessageText.mockRejectedValueOnce({
@@ -616,9 +630,11 @@ describe('editMenu error handling (issue #90 bug 2)', () => {
         fromId,
       ),
     ).resolves.toBeUndefined();
+
+    expect(mockChildLogger.error).not.toHaveBeenCalled();
   });
 
-  it('surfaces a fallback error message when a non-benign Telegram error is raised', async () => {
+  it('logs and surfaces a fallback error message when a non-benign Telegram error is raised', async () => {
     (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);
     (mockPrisma.pot.findMany as jest.Mock).mockResolvedValue([]);
     // First edit (showBalance) fails with a real error → outer catch fires.
@@ -641,6 +657,15 @@ describe('editMenu error handling (issue #90 bug 2)', () => {
     expect(mockEditMessageText).toHaveBeenCalledTimes(2);
     const fallbackText = mockEditMessageText.mock.calls[1][2] as string;
     expect(fallbackText.toLowerCase()).toContain('went wrong');
+    // Two error log lines: editMenu's own + the outer handler's recovery log.
+    expect(mockChildLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ chatId, messageId }),
+      expect.stringContaining('Failed to edit Telegram menu'),
+    );
+    expect(mockChildLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ chatId, action: 'menu_balance' }),
+      expect.stringContaining('menu callback handler failed'),
+    );
   });
 
   it('does not throw when both the primary edit and the fallback edit fail', async () => {
@@ -658,6 +683,96 @@ describe('editMenu error handling (issue #90 bug 2)', () => {
         fromId,
       ),
     ).resolves.toBeUndefined();
+
+    expect(mockChildLogger.error).toHaveBeenCalled();
+  });
+});
+
+describe('mutation/notification split in cancel handlers (issue #90, review feedback)', () => {
+  it('does NOT show "Something went wrong" when expireIntent succeeds but the confirmation edit fails', async () => {
+    mockExpireIntent.mockResolvedValue({ status: 'EXPIRED' });
+    // The single editMessageText call (the success confirmation) fails with a
+    // non-benign Telegram error. The user must NOT see a fallback that invites
+    // a retry on an already-cancelled intent.
+    mockEditMessageText.mockRejectedValue({ error_code: 429, description: 'Too Many Requests' });
+
+    await expect(
+      handleMenuCallback(
+        { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+        chatId,
+        messageId,
+        'menu_cancel_do',
+        'intent-abc',
+        fromId,
+      ),
+    ).resolves.toBeUndefined();
+
+    // Only the success confirmation was attempted — no second "went wrong" edit.
+    expect(mockEditMessageText).toHaveBeenCalledTimes(1);
+    const onlyText = mockEditMessageText.mock.calls[0][2] as string;
+    expect(onlyText.toLowerCase()).not.toContain('went wrong');
+    expect(onlyText.toLowerCase()).toContain('cancelled');
+
+    // The Telegram failure is logged so operators see it, but
+    // doCancelIntent itself is NOT logged as a failure.
+    expect(mockChildLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ chatId, messageId }),
+      expect.stringContaining('Failed to edit Telegram menu'),
+    );
+    const expireFailureLogged = mockChildLogger.error.mock.calls.some((call) =>
+      String(call[1]).includes('expireIntent failed'),
+    );
+    expect(expireFailureLogged).toBe(false);
+  });
+
+  it('does NOT show "Something went wrong" when cancelCard succeeds but the confirmation edit fails', async () => {
+    mockCancelCard.mockResolvedValue(undefined);
+    mockEditMessageText.mockRejectedValue({ error_code: 403, description: 'Bot blocked by user' });
+
+    await expect(
+      handleMenuCallback(
+        { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+        chatId,
+        messageId,
+        'menu_card_cancel',
+        'intent-abc',
+        fromId,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(mockEditMessageText).toHaveBeenCalledTimes(1);
+    const onlyText = mockEditMessageText.mock.calls[0][2] as string;
+    expect(onlyText.toLowerCase()).not.toContain('went wrong');
+    expect(onlyText.toLowerCase()).toContain('cancelled');
+
+    const cancelCardFailureLogged = mockChildLogger.error.mock.calls.some((call) =>
+      String(call[1]).includes('cancelCard failed'),
+    );
+    expect(cancelCardFailureLogged).toBe(false);
+  });
+});
+
+describe('outer recovery catches user-lookup failures (issue #90, review feedback)', () => {
+  it('catches a getUserByChatId DB failure inside the outer recovery block', async () => {
+    (mockPrisma.user.findFirst as jest.Mock).mockRejectedValue(new Error('db unavailable'));
+
+    await expect(
+      handleMenuCallback(
+        { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+        chatId,
+        messageId,
+        'menu_balance',
+        '_',
+        fromId,
+      ),
+    ).resolves.toBeUndefined();
+
+    const text = mockEditMessageText.mock.calls.at(-1)?.[2] as string;
+    expect(text.toLowerCase()).toContain('went wrong');
+    expect(mockChildLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ chatId, action: 'menu_balance' }),
+      expect.stringContaining('menu callback handler failed'),
+    );
   });
 });
 
@@ -686,6 +801,10 @@ describe('TTL payload validation (issue #90 bug 3)', () => {
     expect(mockPrisma.user.update).not.toHaveBeenCalled();
     const text = mockEditMessageText.mock.calls.at(-1)?.[2] as string;
     expect(text.toLowerCase()).toContain('invalid ttl');
+    expect(mockChildLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ chatId, action: 'menu_pref_ttl', payload }),
+      expect.stringContaining('Rejected out-of-range TTL'),
+    );
   });
 
   it.each([
@@ -728,11 +847,41 @@ describe('cancel-policy payload validation (issue #90 bug 3, hardening)', () => 
     expect(mockPrisma.user.update).not.toHaveBeenCalled();
     const text = mockEditMessageText.mock.calls.at(-1)?.[2] as string;
     expect(text.toLowerCase()).toContain('invalid cancel policy');
+    expect(mockChildLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId,
+        action: 'menu_pref_policy',
+        payload: 'NOT_A_REAL_POLICY',
+      }),
+      expect.stringContaining('Rejected unknown cancel policy'),
+    );
+  });
+
+  it('logs a warning for an unknown menu_* action', async () => {
+    (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);
+
+    await handleMenuCallback(
+      { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+      chatId,
+      messageId,
+      'menu_unknown_action',
+      'whatever',
+      fromId,
+    );
+
+    expect(mockChildLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId,
+        action: 'menu_unknown_action',
+        payload: 'whatever',
+      }),
+      expect.stringContaining('Unknown menu_* callback action'),
+    );
   });
 });
 
 describe('error logging in cancel handlers (issue #90 bug 1)', () => {
-  it('does not rethrow when expireIntent fails (doCancelIntent)', async () => {
+  it('does not rethrow when expireIntent fails (doCancelIntent) and logs the failure', async () => {
     mockExpireIntent.mockRejectedValue(new Error('boom'));
 
     await expect(
@@ -747,9 +896,17 @@ describe('error logging in cancel handlers (issue #90 bug 1)', () => {
     ).resolves.toBeUndefined();
     const text = mockEditMessageText.mock.calls.at(-1)?.[2] as string;
     expect(text.toLowerCase()).toContain('went wrong');
+    expect(mockChildLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId,
+        intentId: 'intent-abc',
+        err: expect.any(Error),
+      }),
+      expect.stringContaining('expireIntent failed'),
+    );
   });
 
-  it('does not rethrow when cancelCard fails (doCancelCard)', async () => {
+  it('does not rethrow when cancelCard fails (doCancelCard) and logs the failure', async () => {
     mockCancelCard.mockRejectedValue(new Error('stripe down'));
 
     await expect(
@@ -764,9 +921,17 @@ describe('error logging in cancel handlers (issue #90 bug 1)', () => {
     ).resolves.toBeUndefined();
     const text = mockEditMessageText.mock.calls.at(-1)?.[2] as string;
     expect(text.toLowerCase()).toContain('went wrong');
+    expect(mockChildLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId,
+        intentId: 'intent-abc',
+        err: expect.any(Error),
+      }),
+      expect.stringContaining('cancelCard failed'),
+    );
   });
 
-  it('does not rethrow when an inner show* handler fails (outer catch)', async () => {
+  it('does not rethrow when an inner show* handler fails (outer catch) and logs the failure', async () => {
     (mockPrisma.pot.findMany as jest.Mock).mockRejectedValue(new Error('db unavailable'));
 
     await expect(
@@ -781,5 +946,13 @@ describe('error logging in cancel handlers (issue #90 bug 1)', () => {
     ).resolves.toBeUndefined();
     const text = mockEditMessageText.mock.calls.at(-1)?.[2] as string;
     expect(text.toLowerCase()).toContain('went wrong');
+    expect(mockChildLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId,
+        action: 'menu_balance',
+        err: expect.any(Error),
+      }),
+      expect.stringContaining('menu callback handler failed'),
+    );
   });
 });

--- a/tests/unit/telegram/menuHandler.test.ts
+++ b/tests/unit/telegram/menuHandler.test.ts
@@ -594,3 +594,192 @@ describe('unknown menu_ action', () => {
     ).resolves.toBeUndefined();
   });
 });
+
+// ── observability fixes (issue #90) ───────────────────────────────────────────
+
+describe('editMenu error handling (issue #90 bug 2)', () => {
+  it('swallows the benign "message is not modified" 400 error from Telegram', async () => {
+    (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);
+    (mockPrisma.pot.findMany as jest.Mock).mockResolvedValue([]);
+    mockEditMessageText.mockRejectedValueOnce({
+      error_code: 400,
+      description: 'Bad Request: message is not modified',
+    });
+
+    await expect(
+      handleMenuCallback(
+        { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+        chatId,
+        messageId,
+        'menu_balance',
+        '_',
+        fromId,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('surfaces a fallback error message when a non-benign Telegram error is raised', async () => {
+    (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);
+    (mockPrisma.pot.findMany as jest.Mock).mockResolvedValue([]);
+    // First edit (showBalance) fails with a real error → outer catch fires.
+    // Second edit (the "Something went wrong" surface) must succeed.
+    mockEditMessageText
+      .mockRejectedValueOnce({ error_code: 429, description: 'Too Many Requests' })
+      .mockResolvedValueOnce({});
+
+    await expect(
+      handleMenuCallback(
+        { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+        chatId,
+        messageId,
+        'menu_balance',
+        '_',
+        fromId,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(mockEditMessageText).toHaveBeenCalledTimes(2);
+    const fallbackText = mockEditMessageText.mock.calls[1][2] as string;
+    expect(fallbackText.toLowerCase()).toContain('went wrong');
+  });
+
+  it('does not throw when both the primary edit and the fallback edit fail', async () => {
+    (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);
+    (mockPrisma.pot.findMany as jest.Mock).mockResolvedValue([]);
+    mockEditMessageText.mockRejectedValue({ error_code: 403, description: 'Bot blocked by user' });
+
+    await expect(
+      handleMenuCallback(
+        { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+        chatId,
+        messageId,
+        'menu_balance',
+        '_',
+        fromId,
+      ),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('TTL payload validation (issue #90 bug 3)', () => {
+  beforeEach(() => {
+    (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);
+  });
+
+  it.each([
+    ['negative', '-1'],
+    ['zero', '0'],
+    ['too large', '99999'],
+    ['non-numeric', 'abc'],
+    ['empty', ''],
+    ['fractional', '12.5'],
+  ])('rejects %s TTL payload without writing to the DB', async (_label, payload) => {
+    await handleMenuCallback(
+      { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+      chatId,
+      messageId,
+      'menu_pref_ttl',
+      payload,
+      fromId,
+    );
+
+    expect(mockPrisma.user.update).not.toHaveBeenCalled();
+    const text = mockEditMessageText.mock.calls.at(-1)?.[2] as string;
+    expect(text.toLowerCase()).toContain('invalid ttl');
+  });
+
+  it.each([
+    ['lower bound', '1', 1],
+    ['preset', '60', 60],
+    ['upper bound', '10080', 10080],
+  ])('accepts %s TTL payload (%s) and writes %s to the DB', async (_label, payload, expected) => {
+    await handleMenuCallback(
+      { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+      chatId,
+      messageId,
+      'menu_pref_ttl',
+      payload,
+      fromId,
+    );
+
+    expect(mockPrisma.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: { cancelPolicy: 'AFTER_TTL', cardTtlMinutes: expected },
+      }),
+    );
+  });
+});
+
+describe('cancel-policy payload validation (issue #90 bug 3, hardening)', () => {
+  beforeEach(() => {
+    (mockPrisma.user.findFirst as jest.Mock).mockResolvedValue(baseUser);
+  });
+
+  it('rejects an unknown cancel-policy payload without writing to the DB', async () => {
+    await handleMenuCallback(
+      { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+      chatId,
+      messageId,
+      'menu_pref_policy',
+      'NOT_A_REAL_POLICY',
+      fromId,
+    );
+
+    expect(mockPrisma.user.update).not.toHaveBeenCalled();
+    const text = mockEditMessageText.mock.calls.at(-1)?.[2] as string;
+    expect(text.toLowerCase()).toContain('invalid cancel policy');
+  });
+});
+
+describe('error logging in cancel handlers (issue #90 bug 1)', () => {
+  it('does not rethrow when expireIntent fails (doCancelIntent)', async () => {
+    mockExpireIntent.mockRejectedValue(new Error('boom'));
+
+    await expect(
+      handleMenuCallback(
+        { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+        chatId,
+        messageId,
+        'menu_cancel_do',
+        'intent-abc',
+        fromId,
+      ),
+    ).resolves.toBeUndefined();
+    const text = mockEditMessageText.mock.calls.at(-1)?.[2] as string;
+    expect(text.toLowerCase()).toContain('went wrong');
+  });
+
+  it('does not rethrow when cancelCard fails (doCancelCard)', async () => {
+    mockCancelCard.mockRejectedValue(new Error('stripe down'));
+
+    await expect(
+      handleMenuCallback(
+        { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+        chatId,
+        messageId,
+        'menu_card_cancel',
+        'intent-abc',
+        fromId,
+      ),
+    ).resolves.toBeUndefined();
+    const text = mockEditMessageText.mock.calls.at(-1)?.[2] as string;
+    expect(text.toLowerCase()).toContain('went wrong');
+  });
+
+  it('does not rethrow when an inner show* handler fails (outer catch)', async () => {
+    (mockPrisma.pot.findMany as jest.Mock).mockRejectedValue(new Error('db unavailable'));
+
+    await expect(
+      handleMenuCallback(
+        { api: { sendMessage: mockSendMessage, editMessageText: mockEditMessageText } } as any,
+        chatId,
+        messageId,
+        'menu_balance',
+        '_',
+        fromId,
+      ),
+    ).resolves.toBeUndefined();
+    const text = mockEditMessageText.mock.calls.at(-1)?.[2] as string;
+    expect(text.toLowerCase()).toContain('went wrong');
+  });
+});

--- a/tests/unit/telegram/menuHandler.test.ts
+++ b/tests/unit/telegram/menuHandler.test.ts
@@ -449,7 +449,7 @@ describe('menu_pref_policy', () => {
 
     expect(mockPrisma.user.update).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: { cancelPolicy: 'IMMEDIATE' },
+        data: { cancelPolicy: 'IMMEDIATE', cardTtlMinutes: null },
       }),
     );
     const text = mockEditMessageText.mock.calls[0][2] as string;


### PR DESCRIPTION
Closes #90.

## Summary

The Telegram menu system shipped with three silent-failure patterns that made production debugging impossible and let forged callback payloads bypass input validation. This PR restores observability and tightens the input boundary.

## Bug 1 — Bare `catch { }` blocks discarded every error

`doCancelIntent`, `doCancelCard`, and the outer `handleMenuCallback` each used `catch { }` with no bound variable and no log line, hiding `IntentNotFoundError`, `IllegalTransitionError`, Stripe errors, DB errors, and everything else. In particular, `doCancelIntent` could leave the user thinking their intent was cancelled when it had actually failed — with zero trace.

Each is now `catch (err)` with a structured pino log line at `error` level (including `chatId`, `intentId`/`action`/`payload`, `userId`, and the error itself) before showing the user-facing fallback. The user-visible behaviour is unchanged.

## Bug 2 — `editMenu` swallowed every Telegram API error

The previous `.catch(() => {})` masked 403 (bot blocked), 429 (rate limit), and network failures together with the benign 400 \"message is not modified\" response. Real Telegram failures became completely invisible.

`editMenu` now distinguishes the two: the benign \"message is not modified\" 400 is silently ignored (matched by checking `err.error_code === 400` and `description.includes('message is not modified')`), while every other failure is logged and propagated. The outer error-recovery path uses a small `editMenuSafe` wrapper so a failing recovery edit cannot crash the handler — the secondary failure is logged but not rethrown.

## Bug 3 — Unvalidated TTL/policy payloads from callback data

`parseInt(payload, 10)` was applied to the `menu_pref_ttl` callback payload with no range check, so a crafted callback like `menu_pref_ttl:-1`, `menu_pref_ttl:99999`, or `menu_pref_ttl:12.5` bypassed the API-level 1..10080 bound enforced by the Zod schema in `src/api/routes/users.ts`. The fix validates the payload as an integer-only string within the bound (regex `^[1-9]\\d*$` + numeric range) before calling `savePrefTtl`. Out-of-range values are logged at \`warn\` and surface a \"Must be between 1 and 10080 minutes\" message to the user.

The same class of bug in `menu_pref_policy` — an unchecked `payload as CardCancelPolicy` cast — is fixed at the same time by checking the payload against `Object.values(CardCancelPolicy)` and rejecting unknown values.

Unknown `menu_*` actions, previously silently ignored, are now logged at \`warn\` so a UI that ships a button the backend doesn't handle is visible in logs.

## Tests

`tests/unit/telegram/menuHandler.test.ts` gains **16 new unit tests** in four describe blocks:

- **editMenu error handling** — benign \"message is not modified\" is swallowed; non-benign 429 triggers the fallback edit; double-failure (primary + fallback) doesn't crash.
- **TTL payload validation** — table-driven coverage of negative, zero, too-large, non-numeric, empty, and fractional rejections, plus the three boundary acceptances (1, 60, 10080).
- **Cancel-policy payload validation** — unknown policy rejection.
- **Error logging in cancel handlers** — `expireIntent` failure, `cancelCard` failure, and an inner DB failure all surface the user-facing fallback without rethrowing.

All **39** `menuHandler` unit tests pass (23 pre-existing + 16 new), all **371** unit tests pass, and the existing menu integration tests pass. The two pre-existing failures in `tests/integration/stripe/reconciliation.test.ts` are unrelated (tracked in #88).

## Test plan

```bash
docker compose up -d
npx jest --testPathPattern=unit/telegram/menuHandler --forceExit
# → 39/39 pass

npx jest --testPathPattern=integration/telegram/menuHandler.test.ts --runInBand --forceExit
# → 26/26 pass (17 .live tests skipped without a real bot token)

npx jest --testPathPattern=unit --forceExit
# → 371/371 pass

PORT=3300 npm run dev
curl http://localhost:3300/health
# → {\"status\":\"ok\",...}
```

## Out of scope

- Replacing user-facing copy with provider-specific failure reasons. The fallback messages are intentionally generic; the new structured logs give operators the detail they need.
- Restructuring the menu router. Validation lives at the action boundary; a future router refactor can centralise it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Menu edits are more resilient: harmless "message is not modified" is ignored; other edit failures show a safe fallback without surfacing Telegram edit errors. Cancellation reliably shows confirmation when successful and avoids misleading errors; saving cancel-policy clears any existing TTL. Preference inputs are validated (integer TTL within allowed range; known policies); unknown menu actions now log a warning.

* **Tests**
  * Expanded tests for edit-error handling, cancellation flows, validation, and recovery/logging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JonasBaeumer/AgentWallet/pull/148)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->