### PR TITLE
fix(issue-88): correct ledger-to-Stripe reconciliation across 5 bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3669,6 +3669,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/payments/providers/stripe/reconciliationService.ts
+++ b/src/payments/providers/stripe/reconciliationService.ts
@@ -5,7 +5,10 @@ import type { ReconciliationReport } from '@/contracts';
 
 const log = logger.child({ module: 'payments/stripe/reconciliationService' });
 
-// Safety cap for stripe.issuing.transactions.list pagination.
+// Safety cap for stripe.issuing.transactions.list pagination. A single intent
+// shouldn't generate anywhere near this many transactions; the cap prevents
+// unbounded memory use if a metadata mistake points many transactions at the
+// same card.
 const MAX_TRANSACTIONS = 1000;
 
 export async function reconcileIntent(intentId: string): Promise<ReconciliationReport> {
@@ -20,6 +23,9 @@ export async function reconcileIntent(intentId: string): Promise<ReconciliationR
     ledgerEntries: entries.map((e) => `${e.type}:${e.amount}`),
   };
 
+  // No DB virtual card. The previous behaviour was to return inSync:true
+  // unconditionally — that's a false clean signal whenever the pot shows that
+  // money already moved (settled/returned) without a card record on file.
   if (!card) {
     const discrepancies: string[] = [];
     const moneyMoved =
@@ -41,6 +47,9 @@ export async function reconcileIntent(intentId: string): Promise<ReconciliationR
 
   const stripe = getStripeClient();
 
+  // Wrap the Stripe calls so a 404/429/network blip surfaces as a structured
+  // discrepancy instead of an unhandled exception. The webhook caller's outer
+  // catch already swallows throws silently — we want the audit trail.
   let stripeCard;
   let transactions;
   try {
@@ -63,7 +72,13 @@ export async function reconcileIntent(intentId: string): Promise<ReconciliationR
     };
   }
 
-  // Net captured: Stripe Issuing captures are negative; refunds are positive.
+  // Net captured = sum of capture-side amounts minus refunds.
+  // Stripe Issuing returns capture amounts as NEGATIVE integers (the
+  // cardholder's balance decreases) and refund/return amounts as POSITIVE.
+  // The previous code summed `t.amount` directly, which produced a negative
+  // total that never matched the positive `settledAmount` — every reconcile
+  // run reported a discrepancy. Using Math.abs and sign-correcting by type
+  // gives the comparable positive net.
   let totalCaptured = 0;
   for (const t of transactions) {
     const abs = Math.abs(t.amount);
@@ -91,6 +106,7 @@ export async function reconcileIntent(intentId: string): Promise<ReconciliationR
   if (pot !== null && pot.settledAmount !== totalCaptured) {
     discrepancies.push(`settledAmount ${pot.settledAmount} != stripe captured ${totalCaptured}`);
   }
+
   const expectedCardStatus =
     pot?.status === 'SETTLED' || pot?.status === 'RETURNED' ? 'canceled' : 'active';
   if (stripeCard.status !== expectedCardStatus) {

--- a/src/payments/providers/stripe/reconciliationService.ts
+++ b/src/payments/providers/stripe/reconciliationService.ts
@@ -1,3 +1,4 @@
+import Stripe from 'stripe';
 import { getStripeClient } from './stripeClient';
 import { prisma } from '@/db/client';
 import { logger } from '@/config/logger';
@@ -50,8 +51,8 @@ export async function reconcileIntent(intentId: string): Promise<ReconciliationR
   // Wrap the Stripe calls so a 404/429/network blip surfaces as a structured
   // discrepancy instead of an unhandled exception. The webhook caller's outer
   // catch already swallows throws silently — we want the audit trail.
-  let stripeCard;
-  let transactions;
+  let stripeCard: Stripe.Issuing.Card;
+  let transactions: Stripe.Issuing.Transaction[];
   try {
     stripeCard = await stripe.issuing.cards.retrieve(card.providerCardId);
     transactions = await stripe.issuing.transactions

--- a/tests/integration/stripe/reconciliation.test.ts
+++ b/tests/integration/stripe/reconciliation.test.ts
@@ -117,13 +117,26 @@ describeIfStripe('Reconciliation integration', () => {
   afterAll(async () => {
     // Clean up DB records in FK dependency order. The schema doesn't define
     // ON DELETE CASCADE, so each child table must be cleared explicitly.
-    if (!intentId || !userId) return;
-    await prisma.ledgerEntry.deleteMany({ where: { intentId } }).catch(() => {});
-    await prisma.pot.deleteMany({ where: { intentId } }).catch(() => {});
-    await prisma.virtualCard.deleteMany({ where: { intentId } }).catch(() => {});
-    await prisma.purchaseIntent.deleteMany({ where: { id: intentId } }).catch(() => {});
-    await prisma.user.deleteMany({ where: { id: userId } }).catch(() => {});
-    await prisma.$disconnect();
+    try {
+      // Safety: if beforeAll fails before assigning IDs, never run a deleteMany
+      // with an undefined filter (Prisma can interpret it as no filter).
+      if (intentId) {
+        await prisma.ledgerEntry.deleteMany({ where: { intentId } });
+        await prisma.pot.deleteMany({ where: { intentId } });
+        await prisma.virtualCard.deleteMany({ where: { intentId } });
+        await prisma.purchaseIntent.deleteMany({ where: { id: intentId } });
+      }
+
+      if (userId) {
+        await prisma.user.deleteMany({ where: { id: userId } });
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Reconciliation integration cleanup failed', { intentId, userId, err });
+      throw err;
+    } finally {
+      await prisma.$disconnect();
+    }
   });
 
   it('returns inSync:true when ledger matches Stripe captured amount', async () => {

--- a/tests/integration/stripe/reconciliation.test.ts
+++ b/tests/integration/stripe/reconciliation.test.ts
@@ -84,6 +84,10 @@ describeIfStripe('Reconciliation integration', () => {
       },
     });
 
+    // Simulate a captured transaction. We use createForceCapture (rather than
+    // create+capture on an authorization) because the latter requires the
+    // authorization to first be approved and pending — which in turn needs a
+    // running webhook approver. Force-capture lets the test stay self-contained.
     await stripe.testHelpers.issuing.transactions.createForceCapture({
       card: cardId,
       amount: 3500,
@@ -111,6 +115,9 @@ describeIfStripe('Reconciliation integration', () => {
   }, 60_000);
 
   afterAll(async () => {
+    // Clean up DB records in FK dependency order. The schema doesn't define
+    // ON DELETE CASCADE, so each child table must be cleared explicitly.
+    if (!intentId || !userId) return;
     await prisma.ledgerEntry.deleteMany({ where: { intentId } }).catch(() => {});
     await prisma.pot.deleteMany({ where: { intentId } }).catch(() => {});
     await prisma.virtualCard.deleteMany({ where: { intentId } }).catch(() => {});

--- a/tests/unit/payments/reconciliationService.test.ts
+++ b/tests/unit/payments/reconciliationService.test.ts
@@ -38,7 +38,6 @@ import { reconcileIntent } from '@/payments/providers/stripe/reconciliationServi
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockChildLogger.error.mockClear();
 });
 
 // ── Bug 1: negative Stripe capture amounts ────────────────────────────────────

--- a/tests/unit/payments/reconciliationService.test.ts
+++ b/tests/unit/payments/reconciliationService.test.ts
@@ -1,3 +1,5 @@
+// Mock stripe before imports — autoPagingToArray is the SDK helper used by
+// the service to page through transactions.
 const mockAutoPagingToArray = jest.fn();
 const mockTransactionsList = jest.fn(() => ({ autoPagingToArray: mockAutoPagingToArray }));
 const mockStripe = {
@@ -21,6 +23,7 @@ jest.mock('@/db/client', () => ({
   },
 }));
 
+// Mock logger so we can assert error logging on Stripe failures
 const mockChildLogger = {
   error: jest.fn(),
   warn: jest.fn(),
@@ -38,8 +41,11 @@ beforeEach(() => {
   mockChildLogger.error.mockClear();
 });
 
-describe('reconcileIntent — capture amount sign handling (issue #88)', () => {
+// ── Bug 1: negative Stripe capture amounts ────────────────────────────────────
+
+describe('reconcileIntent — capture amount sign handling (issue #88 bug 1)', () => {
   it('treats Stripe-style negative capture amounts as positive captured totals', async () => {
+    // Real Stripe Issuing returns captures as negative integers.
     mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 3500, status: 'SETTLED' });
     mockLedgerEntries.mockResolvedValue([{ type: 'SETTLE', amount: 3500 }]);
     mockVirtualCard.mockResolvedValue({ intentId: 'intent-1', providerCardId: 'ic_neg' });
@@ -53,7 +59,7 @@ describe('reconcileIntent — capture amount sign handling (issue #88)', () => {
     expect(report.discrepancies).toHaveLength(0);
   });
 
-  it('flags a real settlement mismatch', async () => {
+  it('flags a real settlement mismatch (independent of the sign bug)', async () => {
     mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 3500, status: 'SETTLED' });
     mockLedgerEntries.mockResolvedValue([]);
     mockVirtualCard.mockResolvedValue({ intentId: 'intent-2', providerCardId: 'ic_mis' });
@@ -67,8 +73,11 @@ describe('reconcileIntent — capture amount sign handling (issue #88)', () => {
   });
 });
 
-describe('reconcileIntent — refunds (issue #88)', () => {
+// ── Bug 3: refunds must reduce the net captured ──────────────────────────────
+
+describe('reconcileIntent — refunds (issue #88 bug 3)', () => {
   it('subtracts refund transactions from the net captured total', async () => {
+    // €40 captured, €10 refunded → net €30 — matches a settledAmount of 3000.
     mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 3000, status: 'SETTLED' });
     mockLedgerEntries.mockResolvedValue([{ type: 'SETTLE', amount: 3000 }]);
     mockVirtualCard.mockResolvedValue({ intentId: 'intent-3', providerCardId: 'ic_refund' });
@@ -85,7 +94,9 @@ describe('reconcileIntent — refunds (issue #88)', () => {
   });
 });
 
-describe('reconcileIntent — Stripe API error handling (issue #88)', () => {
+// ── Bug 4: Stripe API errors must surface as discrepancies, not throws ───────
+
+describe('reconcileIntent — Stripe API error handling (issue #88 bug 4)', () => {
   it('returns a discrepancy report instead of throwing when cards.retrieve fails', async () => {
     mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 3500, status: 'SETTLED' });
     mockLedgerEntries.mockResolvedValue([]);
@@ -97,7 +108,11 @@ describe('reconcileIntent — Stripe API error handling (issue #88)', () => {
     expect(report.inSync).toBe(false);
     expect(report.stripe).toBeNull();
     expect(report.discrepancies[0]).toContain('stripe API error');
-    expect(mockChildLogger.error).toHaveBeenCalled();
+    expect(report.discrepancies[0]).toContain('No such card');
+    expect(mockChildLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ intentId: 'intent-err', providerCardId: 'ic_404' }),
+      expect.stringContaining('Stripe API call failed'),
+    );
   });
 
   it('returns a discrepancy report when transactions.list paging fails', async () => {
@@ -115,8 +130,11 @@ describe('reconcileIntent — Stripe API error handling (issue #88)', () => {
   });
 });
 
-describe('reconcileIntent — pagination (issue #88)', () => {
-  it('uses autoPagingToArray with a safety cap', async () => {
+// ── Bug 5: pagination ────────────────────────────────────────────────────────
+
+describe('reconcileIntent — pagination (issue #88 bug 5)', () => {
+  it('uses autoPagingToArray with a safety cap so paged transactions are summed', async () => {
+    // 250 captures of -10 → totalCaptured 2500.
     const txs = Array.from({ length: 250 }, (_, i) => ({
       id: `itxn_${i}`,
       amount: -10,
@@ -135,7 +153,7 @@ describe('reconcileIntent — pagination (issue #88)', () => {
     expect(report.inSync).toBe(true);
   });
 
-  it('flags a discrepancy when the safety cap is hit', async () => {
+  it('flags a discrepancy when the safety cap is hit (totalCaptured is incomplete)', async () => {
     const txs = Array.from({ length: 1000 }, (_, i) => ({
       id: `itxn_${i}`,
       amount: -1,
@@ -154,8 +172,10 @@ describe('reconcileIntent — pagination (issue #88)', () => {
   });
 });
 
-describe('reconcileIntent — missing virtualCard (issue #88)', () => {
-  it('returns inSync:true when neither pot nor card exists', async () => {
+// ── Bug 2: missing virtualCard with money already moved ───────────────────────
+
+describe('reconcileIntent — missing virtualCard (issue #88 bug 2)', () => {
+  it('returns inSync:true when neither pot nor card exists (truly empty intent)', async () => {
     mockPot.mockResolvedValue(null);
     mockLedgerEntries.mockResolvedValue([]);
     mockVirtualCard.mockResolvedValue(null);
@@ -167,7 +187,9 @@ describe('reconcileIntent — missing virtualCard (issue #88)', () => {
     expect(mockStripe.issuing.cards.retrieve).not.toHaveBeenCalled();
   });
 
-  it('returns inSync:true when pot is ACTIVE with no settled funds (in-flight)', async () => {
+  it('returns inSync:true when a pot exists but is still ACTIVE with no settled funds (in-flight)', async () => {
+    // Normal lifecycle: reserveForIntent creates the pot before issueCard
+    // creates the virtualCard. Between those two, this is the expected state.
     mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 0, status: 'ACTIVE' });
     mockLedgerEntries.mockResolvedValue([{ type: 'RESERVE', amount: 5000 }]);
     mockVirtualCard.mockResolvedValue(null);
@@ -189,8 +211,25 @@ describe('reconcileIntent — missing virtualCard (issue #88)', () => {
     expect(
       report.discrepancies.some((d) => d.includes('virtualCard missing') && d.includes('SETTLED')),
     ).toBe(true);
+    expect(mockStripe.issuing.cards.retrieve).not.toHaveBeenCalled();
+  });
+
+  it('returns inSync:false when pot is RETURNED but no virtualCard record exists', async () => {
+    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 0, status: 'RETURNED' });
+    mockLedgerEntries.mockResolvedValue([
+      { type: 'RESERVE', amount: 5000 },
+      { type: 'RETURN', amount: 5000 },
+    ]);
+    mockVirtualCard.mockResolvedValue(null);
+
+    const report = await reconcileIntent('intent-orphaned-returned');
+
+    expect(report.inSync).toBe(false);
+    expect(report.discrepancies.some((d) => d.includes('RETURNED'))).toBe(true);
   });
 });
+
+// ── Card-status discrepancy (pre-existing behaviour, kept) ───────────────────
 
 describe('reconcileIntent — card status', () => {
   it('reports a discrepancy when pot is SETTLED but Stripe card is still active', async () => {
@@ -208,6 +247,8 @@ describe('reconcileIntent — card status', () => {
     ).toBe(true);
   });
 });
+
+// ── Internal report fields (pre-existing behaviour, kept) ─────────────────────
 
 describe('reconcileIntent — internal report fields', () => {
   it('reports zero balances and null potStatus when no pot exists', async () => {


### PR DESCRIPTION
Closes #88.

## Summary

The reconciliation feature reported false discrepancies on every settled intent and had no error handling around its Stripe calls. All five bugs listed in the issue are addressed.

## Bug 1 — Sign convention

Stripe Issuing returns capture amounts as **negative** integers (e.g. a €35 charge is `amount: -3500`) and refunds as positive. The previous code summed `t.amount` directly and compared the resulting negative number to a positive `settledAmount`, producing a discrepancy on every run.

`totalCaptured` is now computed as `sum of |amount| for non-refunds minus |amount| for refunds`, giving the comparable positive net.

## Bug 3 — Refunds excluded

The list query previously filtered with `type: 'capture'`, so a partial refund overstated `totalCaptured`. The filter is removed; refunds are now subtracted from the net (combined with the bug 1 fix above).

## Bug 5 — Pagination

`stripe.issuing.transactions.list` returned at most 100 rows by default, silently understating `totalCaptured` for high-volume intents. We now use `autoPagingToArray({ limit: 1000 })` and emit a discrepancy if the safety cap is hit so the truncation is visible rather than silent.

## Bug 4 — Stripe API error handling

`cards.retrieve` and `transactions.list` are wrapped in try/catch. A 404 / 429 / network blip now produces a structured discrepancy report (`{ inSync: false, stripe: null, discrepancies: ['stripe API error: ...'] }`) and a logged error, instead of an unhandled exception that the webhook caller's outer `.catch` swallowed without trace.

## Bug 2 — Missing virtualCard

The previous behaviour returned `{ inSync: true }` whenever no `VirtualCard` row existed — even when the pot showed money had already moved (settled / returned). That's a false clean signal. The check now distinguishes:

- no card AND (no pot OR active in-flight pot) → `inSync: true` *(the in-flight case is the normal state between `reserveForIntent` creating the pot and `issueCard` creating the card)*
- no card AND settled / returned pot → `inSync: false` with discrepancy `virtualCard missing for intent with pot status SETTLED (settledAmount 3500)`

## Tests

**Unit**: 14 new tests in `tests/unit/payments/reconciliationService.test.ts` cover each bug independently: negative-amount handling, refund netting, both Stripe-error paths (`cards.retrieve` and `transactions.list`), paging with the safety cap, truncation discrepancy, all four no-card states (no-pot, in-flight, SETTLED, RETURNED), plus the pre-existing card-status check.

**Integration** (`tests/integration/stripe/reconciliation.test.ts`): was previously broken at setup (missing required `idempotencyKey` on `PurchaseIntent`, missing `userId` on `Pot` and `LedgerEntry`, and a `testHelpers.authorizations.create` + `.capture` sequence that needs a running webhook approver to succeed). Switched to `testHelpers.issuing.transactions.createForceCapture` so the test stays self-contained, supplied the required fields, and improved cleanup to delete child rows in FK order. **Both integration tests now PASS for the first time** against real Stripe test mode.

This also removes the pre-existing reconciliation failures I'd been flagging in the PR descriptions of #147 and #148.

## Test plan

```bash
docker compose up -d
npx jest --testPathPattern=unit/payments/reconciliationService --forceExit
# → 14/14 pass

npx jest --testPathPattern=integration/stripe/reconciliation --runInBand --forceExit
# → 2/2 pass (real Stripe API)

npm run test:integration
# → all suites pass (no failures left)

npm run format:check          # passes
npx eslint src/payments/providers/stripe/reconciliationService.ts  # 0 errors
PORT=3411 npm run dev && curl http://localhost:3411/health
# → {"status":"ok",...}
```

## Out of scope

- The webhook caller's fire-and-forget reconciliation pattern (`reconcileIntent(intentId).then(...)` in `webhookHandler.ts`). With this PR the reconciliation no longer throws on Stripe failures — it surfaces them as audited discrepancies — so the webhook's outer `.catch` is now a true belt-and-braces.
- Scanning Stripe for orphaned cards when the DB row is missing. Bug 2 is fixed by treating "settled pot, no DB card" as a discrepancy in the audit report; proactive Stripe-side scanning is a more invasive change for a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reconciliation now returns structured discrepancy reports (no throws) on Stripe/API errors and logs via a scoped logger.
  * Net captured amount calculation fixed to treat transaction amounts/signs correctly and subtract refunds.
  * Adds a safety cap for transaction pagination and flags when results are truncated.
  * Improves detection of moved funds when a matching card is absent.

* **Tests**
  * Expanded integration and unit tests for reconciliation edge cases, pagination, and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JonasBaeumer/AgentWallet/pull/149)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->