### PR TITLE
feat(issue-105): payment-provider abstraction (clean signed redo of #129)

### DIFF
--- a/prisma/migrations/20260418000000_payment_provider_abstraction/migration.sql
+++ b/prisma/migrations/20260418000000_payment_provider_abstraction/migration.sql
@@ -1,0 +1,10 @@
+-- CreateEnum
+CREATE TYPE "PaymentProvider" AS ENUM ('STRIPE');
+
+-- AlterTable User: add paymentProvider, rename stripeCardholderId -> providerCardholderId
+ALTER TABLE "User" ADD COLUMN "paymentProvider" "PaymentProvider" NOT NULL DEFAULT 'STRIPE';
+ALTER TABLE "User" RENAME COLUMN "stripeCardholderId" TO "providerCardholderId";
+
+-- AlterTable VirtualCard: rename stripeCardId -> providerCardId, rename its unique index
+ALTER TABLE "VirtualCard" RENAME COLUMN "stripeCardId" TO "providerCardId";
+ALTER INDEX "VirtualCard_stripeCardId_key" RENAME TO "VirtualCard_providerCardId_key";

--- a/prisma/migrations/20260504000000_scope_virtualcard_unique_per_provider/migration.sql
+++ b/prisma/migrations/20260504000000_scope_virtualcard_unique_per_provider/migration.sql
@@ -1,0 +1,16 @@
+-- Scope VirtualCard.providerCardId uniqueness per provider.
+-- Existing rows are all STRIPE-issued, so we add the column with a STRIPE
+-- default to backfill, then drop the default — going forward every
+-- write site must set provider explicitly so a future provider cannot be
+-- silently mis-tagged as STRIPE.
+
+ALTER TABLE "VirtualCard"
+  ADD COLUMN "provider" "PaymentProvider" NOT NULL DEFAULT 'STRIPE';
+
+ALTER TABLE "VirtualCard"
+  ALTER COLUMN "provider" DROP DEFAULT;
+
+DROP INDEX "VirtualCard_providerCardId_key";
+
+CREATE UNIQUE INDEX "VirtualCard_provider_providerCardId_key"
+  ON "VirtualCard" ("provider", "providerCardId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,26 +45,31 @@ enum CardCancelPolicy {
   MANUAL
 }
 
-model User {
-  id                  String          @id @default(cuid())
-  email               String          @unique
-  mainBalance         Int             @default(0)
-  maxBudgetPerIntent  Int             @default(50000)
-  merchantAllowlist   String[]        @default([])
-  mccAllowlist        String[]        @default([])
-  stripeCardholderId  String?
-  telegramChatId      String?
-  phoneNumber         String?
-  agentId             String?         @unique
-  apiKeyHash          String?
-  apiKeyPrefix        String?         @unique
-  cancelPolicy        CardCancelPolicy @default(ON_TRANSACTION)
-  cardTtlMinutes      Int?
-  createdAt           DateTime        @default(now())
+enum PaymentProvider {
+  STRIPE
+}
 
-  intents             PurchaseIntent[]
-  ledgerEntries       LedgerEntry[]
-  pots                Pot[]
+model User {
+  id                     String           @id @default(cuid())
+  email                  String           @unique
+  mainBalance            Int              @default(0)
+  maxBudgetPerIntent     Int              @default(50000)
+  merchantAllowlist      String[]         @default([])
+  mccAllowlist           String[]         @default([])
+  paymentProvider        PaymentProvider  @default(STRIPE)
+  providerCardholderId   String?
+  telegramChatId         String?
+  phoneNumber            String?
+  agentId                String?          @unique
+  apiKeyHash             String?
+  apiKeyPrefix           String?          @unique
+  cancelPolicy           CardCancelPolicy @default(ON_TRANSACTION)
+  cardTtlMinutes         Int?
+  createdAt              DateTime         @default(now())
+
+  intents                PurchaseIntent[]
+  ledgerEntries          LedgerEntry[]
+  pots                   Pot[]
 }
 
 model PairingCode {
@@ -99,16 +104,27 @@ model PurchaseIntent {
 }
 
 model VirtualCard {
-  id           String    @id @default(cuid())
-  intentId     String    @unique
-  stripeCardId String    @unique
-  last4        String
-  revealedAt   DateTime?
-  frozenAt     DateTime?
-  cancelledAt  DateTime?
-  createdAt    DateTime  @default(now())
+  id             String          @id @default(cuid())
+  intentId       String          @unique
+  // Which provider issued this card. Pinned at creation so we never have to
+  // infer it later (a user can only switch providers via account-level reset
+  // — see #128 — so the user's current paymentProvider is not authoritative
+  // for historical cards). No default — every write site must set it
+  // explicitly so a future provider can't be silently mis-tagged as STRIPE.
+  provider       PaymentProvider
+  providerCardId String
+  last4          String
+  revealedAt     DateTime?
+  frozenAt       DateTime?
+  cancelledAt    DateTime?
+  createdAt      DateTime        @default(now())
 
-  intent       PurchaseIntent @relation(fields: [intentId], references: [id])
+  intent         PurchaseIntent @relation(fields: [intentId], references: [id])
+
+  // Provider-scoped uniqueness: providerCardId is only unique within a given
+  // provider's id-space (Stripe `ic_*` and Privacy `card_*` cannot collide
+  // today, but we don't want to depend on that).
+  @@unique([provider, providerCardId])
 }
 
 model LedgerEntry {

--- a/src/api/routes/agent.ts
+++ b/src/api/routes/agent.ts
@@ -10,7 +10,7 @@ import {
   failCheckout,
 } from '@/orchestrator/intentService';
 import { settleIntent, returnIntent } from '@/ledger/potService';
-import { getPaymentProvider } from '@/payments';
+import { getProviderForIntent } from '@/payments';
 import { prisma } from '@/db/client';
 import { sendApprovalRequest } from '@/telegram/notificationService';
 
@@ -98,10 +98,14 @@ export async function agentRoutes(fastify: FastifyInstance): Promise<void> {
         await returnIntent(intentId);
       }
 
-      // Cancel the virtual card — one purchase, one card (best-effort)
-      await getPaymentProvider()
-        .cancelCard(intentId)
-        .catch(() => {});
+      // Cancel the virtual card — one purchase, one card (best-effort).
+      // Failures must not block the agent response, but a swallowed error can
+      // leave a live card on Stripe — log so it shows up in oncall.
+      await getProviderForIntent(intentId)
+        .then((p) => p.cancelCard(intentId))
+        .catch((err: unknown) => {
+          fastify.log.warn({ intentId, err }, 'Failed to cancel virtual card after agent result');
+        });
 
       // Store receipt/error info in metadata
       await prisma.purchaseIntent.update({
@@ -189,13 +193,14 @@ export async function agentRoutes(fastify: FastifyInstance): Promise<void> {
       const { intentId } = request.params;
 
       try {
-        const reveal = await getPaymentProvider().revealCard(intentId);
+        const provider = await getProviderForIntent(intentId);
+        const reveal = await provider.revealCard(intentId);
         return reply.send({ intentId, ...reveal });
       } catch (err: any) {
         if (err.name === 'CardAlreadyRevealedError') {
           return reply.status(409).send({ error: 'Card has already been revealed' });
         }
-        if (err.name === 'IntentNotFoundError') {
+        if (err.name === 'IntentNotFoundError' || err.code === 'P2025') {
           return reply.status(404).send({ error: `No card found for intent: ${intentId}` });
         }
         throw err;

--- a/src/api/routes/approvals.ts
+++ b/src/api/routes/approvals.ts
@@ -8,10 +8,13 @@ import {
   IntentStatus,
   InsufficientFundsError,
   InsufficientIssuingBalanceError,
+  IntentNotFoundError,
+  UserNotFoundError,
 } from '@/contracts';
 import { recordDecision } from '@/approval/approvalService';
 import { reserveForIntent, returnIntent } from '@/ledger/potService';
 import { getPaymentProvider } from '@/payments';
+import type { IPaymentProvider } from '@/contracts';
 import { markCardIssued, startCheckout } from '@/orchestrator/intentService';
 import { enqueueCheckout } from '@/queue/producers';
 
@@ -73,14 +76,15 @@ export async function approvalRoutes(fastify: FastifyInstance): Promise<void> {
 
         if (decisionType === ApprovalDecisionType.APPROVED) {
           const metadata = intent.metadata as Record<string, unknown>;
+          const provider: IPaymentProvider = getPaymentProvider(intent.user.paymentProvider);
 
-          // 1. Check Stripe Issuing balance BEFORE persisting the decision
-          const issuingBalance = await getPaymentProvider().getIssuingBalance(intent.currency);
+          // 1. Check issuing balance BEFORE persisting the decision
+          const issuingBalance = await provider.getIssuingBalance();
           if (issuingBalance.available < intent.maxBudget) {
             throw new InsufficientIssuingBalanceError(
               issuingBalance.available,
               intent.maxBudget,
-              intent.currency,
+              issuingBalance.currency,
             );
           }
 
@@ -92,15 +96,10 @@ export async function approvalRoutes(fastify: FastifyInstance): Promise<void> {
 
           let card;
           try {
-            // 4. Issue restricted Stripe virtual card
-            card = await getPaymentProvider().issueCard(
-              intentId,
-              intent.maxBudget,
-              intent.currency,
-              {
-                mccAllowlist: intent.user.mccAllowlist,
-              },
-            );
+            // 4. Issue restricted virtual card
+            card = await provider.issueCard(intentId, intent.maxBudget, {
+              mccAllowlist: intent.user.mccAllowlist,
+            });
           } catch (cardErr) {
             await returnIntent(intentId).catch(() => {});
             throw cardErr;
@@ -120,7 +119,7 @@ export async function approvalRoutes(fastify: FastifyInstance): Promise<void> {
             merchantUrl: (metadata.merchantUrl as string) ?? '',
             price: (metadata.price as number) ?? intent.maxBudget,
             currency: intent.currency,
-            stripeCardId: card.stripeCardId,
+            providerCardId: card.providerCardId,
             last4: card.last4,
           });
 
@@ -140,6 +139,14 @@ export async function approvalRoutes(fastify: FastifyInstance): Promise<void> {
           err instanceof InsufficientIssuingBalanceError
         ) {
           return reply.status(422).send({ error: err.message });
+        }
+        // The route already 404s on a missing intent and 403s on a
+        // foreign-owned intent before reaching this catch. These typed errors
+        // would only fire if the intent was deleted between those checks and
+        // reserveForIntent — defensive but mapped to 404 so the client sees
+        // a stable contract instead of a 500.
+        if (err instanceof IntentNotFoundError || err instanceof UserNotFoundError) {
+          return reply.status(404).send({ error: err.message });
         }
         throw err;
       }

--- a/src/api/routes/intents.ts
+++ b/src/api/routes/intents.ts
@@ -6,6 +6,7 @@ import { createIntentSchema } from '@/api/validators/intents';
 import { IntentStatus } from '@/contracts';
 import { startSearching } from '@/orchestrator/intentService';
 import { enqueueSearch } from '@/queue/producers';
+import { getPaymentProvider } from '@/payments';
 
 export async function intentRoutes(fastify: FastifyInstance): Promise<void> {
   // POST /v1/intents
@@ -39,7 +40,11 @@ export async function intentRoutes(fastify: FastifyInstance): Promise<void> {
 
       const user = request.user!;
       const userId = user.id;
-      const { query, subject, maxBudget, currency, expiresAt } = parsed.data;
+      const { query, subject, maxBudget, expiresAt } = parsed.data;
+
+      // Currency is derived from the user's payment provider — not caller-supplied —
+      // so ledger entries and card issuance can never diverge.
+      const currency = getPaymentProvider(user.paymentProvider).metadata.currency;
 
       const intent = await prisma.purchaseIntent.create({
         data: {

--- a/src/api/routes/webhooks.ts
+++ b/src/api/routes/webhooks.ts
@@ -1,8 +1,12 @@
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { getPaymentProvider } from '@/payments';
+import { PaymentProvider } from '@/contracts';
+import { stripeWebhookHeadersSchema } from '@/api/validators/webhooks';
 
 export async function webhookRoutes(fastify: FastifyInstance): Promise<void> {
   // Raw body is preserved for this path by app's content-type parser (required for Stripe signature verification).
+  // The route hardcodes PaymentProvider.STRIPE because each provider has its own webhook path
+  // with provider-specific signature schemes (Privacy.com will add /v1/webhooks/privacy in #106).
   fastify.post(
     '/v1/webhooks/stripe',
     {
@@ -15,15 +19,19 @@ export async function webhookRoutes(fastify: FastifyInstance): Promise<void> {
       },
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
-      const signature = request.headers['stripe-signature'] as string;
-      if (!signature) {
+      const parsed = stripeWebhookHeadersSchema.safeParse(request.headers);
+      if (!parsed.success) {
         return reply.status(400).send({ error: 'Missing stripe-signature header' });
       }
+      const signature = parsed.data['stripe-signature'];
 
       let response: Record<string, unknown> = { received: true };
       try {
         const body = request.body as Buffer | string;
-        response = await getPaymentProvider().handleWebhookEvent(body, signature);
+        response = await getPaymentProvider(PaymentProvider.STRIPE).handleWebhookEvent(
+          body,
+          signature,
+        );
       } catch (err) {
         // Log but always return 200 to Stripe to prevent retries
         fastify.log.error({ message: 'Stripe webhook processing error', error: String(err) });

--- a/src/api/validators/agent.ts
+++ b/src/api/validators/agent.ts
@@ -5,7 +5,7 @@ export const agentQuoteSchema = z.object({
   merchantName: z.string().min(1),
   merchantUrl: z.string().url(),
   price: z.number().int().positive(),
-  currency: z.string().length(3).default('gbp'),
+  currency: z.string().length(3).default('eur'),
 });
 
 export const agentResultSchema = z.object({

--- a/src/api/validators/intents.ts
+++ b/src/api/validators/intents.ts
@@ -4,7 +4,6 @@ export const createIntentSchema = z.object({
   query: z.string().min(1).max(500),
   subject: z.string().min(1).max(100).optional(),
   maxBudget: z.number().int().positive().max(1000000), // max €10,000 in cents
-  currency: z.string().length(3).default('eur'),
   expiresAt: z.string().datetime().optional(),
 });
 

--- a/src/api/validators/webhooks.ts
+++ b/src/api/validators/webhooks.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+// Validates the `stripe-signature` header on the Stripe webhook route.
+// Headers are lowercased by Fastify; we read the value with the lowercase key.
+export const stripeWebhookHeadersSchema = z.object({
+  'stripe-signature': z.string().min(1),
+});
+
+export type StripeWebhookHeaders = z.infer<typeof stripeWebhookHeadersSchema>;

--- a/src/contracts/card.ts
+++ b/src/contracts/card.ts
@@ -1,7 +1,11 @@
+import type { PaymentProvider } from './payment';
+
 export interface VirtualCardData {
   id: string;
   intentId: string;
-  stripeCardId: string;
+  // Pinned at issuance — see prisma/schema.prisma VirtualCard.
+  provider: PaymentProvider;
+  providerCardId: string;
   last4: string;
   revealedAt: Date | null;
   frozenAt: Date | null;

--- a/src/contracts/errors.ts
+++ b/src/contracts/errors.ts
@@ -12,6 +12,13 @@ export class IntentNotFoundError extends Error {
   }
 }
 
+export class UserNotFoundError extends Error {
+  constructor(userId: string) {
+    super(`User not found: ${userId}`);
+    this.name = 'UserNotFoundError';
+  }
+}
+
 export class InvalidApprovalStateError extends Error {
   constructor(intentId: string, currentStatus: string) {
     super(`Intent ${intentId} is not in AWAITING_APPROVAL state (current: ${currentStatus})`);

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -8,3 +8,4 @@ export * from './errors';
 export * from './services';
 export * from './agent';
 export * from './reconciliation';
+export * from './payment';

--- a/src/contracts/jobs.ts
+++ b/src/contracts/jobs.ts
@@ -14,6 +14,6 @@ export interface CheckoutIntentJob {
   merchantUrl: string;
   price: number;
   currency: string;
-  stripeCardId: string;
+  providerCardId: string;
   last4: string;
 }

--- a/src/contracts/payment.ts
+++ b/src/contracts/payment.ts
@@ -1,0 +1,13 @@
+import { PaymentProvider } from '@prisma/client';
+
+export { PaymentProvider };
+
+/**
+ * Describes a payment provider's defaults. Additional fields
+ * (displayName, authorizationModel, autoCancelAfterUse, supportsFreeze)
+ * will be added alongside their first consumer in the Privacy.com PR (#106).
+ */
+export interface ProviderMetadata {
+  id: PaymentProvider;
+  currency: string;
+}

--- a/src/contracts/services.ts
+++ b/src/contracts/services.ts
@@ -4,6 +4,7 @@ import { ApprovalDecisionData, ApprovalDecisionType } from './approval';
 import { PotData } from './ledger';
 import { SearchIntentJob, CheckoutIntentJob } from './jobs';
 import { AuditEventData } from './audit';
+import { ProviderMetadata } from './payment';
 
 export interface IOrchestrator {
   transitionIntent(
@@ -22,17 +23,17 @@ export interface IssuingBalance {
 }
 
 export interface IPaymentProvider {
+  readonly metadata: ProviderMetadata;
   issueCard(
     intentId: string,
     amount: number,
-    currency: string,
     options?: { mccAllowlist?: string[] },
   ): Promise<VirtualCardData>;
   revealCard(intentId: string): Promise<CardReveal>;
   freezeCard(intentId: string): Promise<void>;
   cancelCard(intentId: string): Promise<void>;
   handleWebhookEvent(rawBody: Buffer | string, signature: string): Promise<Record<string, unknown>>;
-  getIssuingBalance(currency: string): Promise<IssuingBalance>;
+  getIssuingBalance(): Promise<IssuingBalance>;
 }
 
 export interface IApprovalService {

--- a/src/ledger/potService.ts
+++ b/src/ledger/potService.ts
@@ -5,6 +5,7 @@ import {
   PotData,
   InsufficientFundsError,
   IntentNotFoundError,
+  UserNotFoundError,
 } from '@/contracts';
 import { logger } from '@/config/logger';
 
@@ -17,8 +18,17 @@ export async function reserveForIntent(
 ): Promise<PotData> {
   log.info({ intentId, userId, amount }, 'Reserving funds');
   return await prisma.$transaction(async (tx) => {
+    // Fetch userId alongside currency so we can verify the intent belongs to
+    // the caller. Without this check a mismatched (userId, intentId) pair
+    // would attach this user's pot/ledger entries to another user's intent.
+    const intent = await tx.purchaseIntent.findUnique({
+      where: { id: intentId },
+      select: { currency: true, userId: true },
+    });
+    if (!intent || intent.userId !== userId) throw new IntentNotFoundError(intentId);
+
     const user = await tx.user.findUnique({ where: { id: userId } });
-    if (!user) throw new Error(`User not found: ${userId}`);
+    if (!user) throw new UserNotFoundError(userId);
     if (user.mainBalance < amount) throw new InsufficientFundsError(user.mainBalance, amount);
 
     // Deduct from mainBalance
@@ -37,7 +47,13 @@ export async function reserveForIntent(
 
     // Record ledger entry
     await tx.ledgerEntry.create({
-      data: { userId, intentId, type: LedgerEntryType.RESERVE, amount, currency: 'gbp' },
+      data: {
+        userId,
+        intentId,
+        type: LedgerEntryType.RESERVE,
+        amount,
+        currency: intent.currency,
+      },
     });
 
     return pot as unknown as PotData;
@@ -49,6 +65,12 @@ export async function settleIntent(intentId: string, actualAmount: number): Prom
   await prisma.$transaction(async (tx) => {
     const pot = await tx.pot.findUnique({ where: { intentId } });
     if (!pot) throw new IntentNotFoundError(intentId);
+
+    const intent = await tx.purchaseIntent.findUnique({
+      where: { id: intentId },
+      select: { currency: true },
+    });
+    if (!intent) throw new IntentNotFoundError(intentId);
 
     const surplus = pot.reservedAmount - actualAmount;
 
@@ -73,7 +95,7 @@ export async function settleIntent(intentId: string, actualAmount: number): Prom
         intentId,
         type: LedgerEntryType.SETTLE,
         amount: actualAmount,
-        currency: 'gbp',
+        currency: intent.currency,
       },
     });
   });
@@ -86,6 +108,12 @@ export async function returnIntent(intentId: string): Promise<void> {
     if (!pot) return; // Nothing to return if pot doesn't exist
 
     if (pot.status !== PotStatus.ACTIVE) return; // Already settled/returned
+
+    const intent = await tx.purchaseIntent.findUnique({
+      where: { id: intentId },
+      select: { currency: true },
+    });
+    if (!intent) throw new IntentNotFoundError(intentId);
 
     // Return full reserved amount
     await tx.user.update({
@@ -103,7 +131,7 @@ export async function returnIntent(intentId: string): Promise<void> {
         intentId,
         type: LedgerEntryType.RETURN,
         amount: pot.reservedAmount,
-        currency: 'gbp',
+        currency: intent.currency,
       },
     });
   });

--- a/src/orchestrator/intentService.ts
+++ b/src/orchestrator/intentService.ts
@@ -4,7 +4,7 @@ import { logger } from '@/config/logger';
 
 const log = logger.child({ module: 'orchestrator/intentService' });
 import { transitionIntent, TransitionResult } from './stateMachine';
-import { getPaymentProvider } from '@/payments';
+import { getPaymentProvider, getProviderForIntent } from '@/payments';
 import { returnIntent } from '@/ledger/potService';
 import { enqueueCancelCard } from '@/queue/producers';
 import { getTelegramBot } from '@/telegram/telegramClient';
@@ -85,38 +85,50 @@ async function applyPostCheckoutCancelPolicy(intentId: string): Promise<void> {
   const intent = await prisma.purchaseIntent.findUnique({
     where: { id: intentId },
     include: {
-      user: { select: { cancelPolicy: true, cardTtlMinutes: true, telegramChatId: true } },
+      user: {
+        select: {
+          cancelPolicy: true,
+          cardTtlMinutes: true,
+          telegramChatId: true,
+          paymentProvider: true,
+        },
+      },
       virtualCard: true,
     },
   });
   if (!intent?.user) return;
 
-  const { cancelPolicy, cardTtlMinutes, telegramChatId } = intent.user;
+  const { cancelPolicy, cardTtlMinutes, telegramChatId, paymentProvider } = intent.user;
+  const provider = getPaymentProvider(paymentProvider);
 
   if (cancelPolicy === 'ON_TRANSACTION') {
     // Cancellation is handled by the issuing_transaction.created Stripe webhook.
     // Fallback for stub/test flows where no real Stripe transaction fires:
     if (!intent.virtualCard) {
-      await getPaymentProvider()
-        .cancelCard(intentId)
-        .catch((err) => {
-          log.error({ intentId, err }, 'ON_TRANSACTION stub fallback cancel failed');
-        });
+      await provider.cancelCard(intentId).catch((err) => {
+        log.error({ intentId, err }, 'ON_TRANSACTION stub fallback cancel failed');
+      });
     }
   } else if (cancelPolicy === 'IMMEDIATE') {
-    await getPaymentProvider()
-      .cancelCard(intentId)
-      .catch((err) => {
-        log.error({ intentId, err }, 'IMMEDIATE card cancel failed');
+    await provider.cancelCard(intentId).catch((err) => {
+      log.error({ intentId, err }, 'IMMEDIATE card cancel failed');
+    });
+  } else if (cancelPolicy === 'AFTER_TTL' && cardTtlMinutes != null) {
+    // cardTtlMinutes <= 0 means cancel immediately rather than enqueueing a
+    // 0-delay job (avoids a queue round-trip and a job that races the
+    // checkout response). Truthy check would treat 0 as "unset" and silently
+    // leave the card live.
+    if (cardTtlMinutes <= 0) {
+      await provider.cancelCard(intentId).catch((err) => {
+        log.error({ intentId, err }, 'AFTER_TTL immediate card cancel failed');
       });
-  } else if (cancelPolicy === 'AFTER_TTL' && cardTtlMinutes) {
-    await enqueueCancelCard(intentId, cardTtlMinutes * 60 * 1000);
+    } else {
+      await enqueueCancelCard(intentId, cardTtlMinutes * 60 * 1000);
+    }
   } else if (cancelPolicy === 'MANUAL') {
-    await getPaymentProvider()
-      .freezeCard(intentId)
-      .catch((err) => {
-        log.error({ intentId, err }, 'MANUAL card freeze failed');
-      });
+    await provider.freezeCard(intentId).catch((err) => {
+      log.error({ intentId, err }, 'MANUAL card freeze failed');
+    });
     if (telegramChatId) {
       await notifyManualCardPending(telegramChatId, intentId, intent.subject ?? intent.query);
     }
@@ -151,8 +163,8 @@ export async function failCheckout(
 async function cleanupExpiredIntent(intentId: string): Promise<void> {
   const card = await prisma.virtualCard.findUnique({ where: { intentId } });
   if (card) {
-    await getPaymentProvider()
-      .cancelCard(intentId)
+    await getProviderForIntent(intentId)
+      .then((p) => p.cancelCard(intentId))
       .catch((err) => {
         log.error({ intentId, err }, 'Failed to cancel card during expiry cleanup');
       });

--- a/src/payments/index.ts
+++ b/src/payments/index.ts
@@ -1,2 +1,2 @@
 // Production API — callers should use the provider factory
-export { getPaymentProvider } from './providerFactory';
+export { getPaymentProvider, getProviderForUser, getProviderForIntent } from './providerFactory';

--- a/src/payments/providerFactory.ts
+++ b/src/payments/providerFactory.ts
@@ -1,29 +1,82 @@
+import { Prisma } from '@prisma/client';
 import { env } from '@/config/env';
-import { IPaymentProvider } from '@/contracts';
+import { prisma } from '@/db/client';
+import {
+  IPaymentProvider,
+  IntentNotFoundError,
+  PaymentProvider,
+  UserNotFoundError,
+} from '@/contracts';
 
-let _provider: IPaymentProvider | null = null;
+const MOCK_PREFIX = '__mock__:';
+const instances = new Map<string, IPaymentProvider>();
 
-export function getPaymentProvider(): IPaymentProvider {
-  if (_provider) return _provider;
+function useMockProvider(): boolean {
+  return env.NODE_ENV === 'test' || env.PAYMENT_PROVIDER === 'mock';
+}
 
-  const name = env.PAYMENT_PROVIDER;
+export function getPaymentProvider(providerType: PaymentProvider): IPaymentProvider {
+  // Mock instances are cached per-providerType so callers branching on
+  // provider.metadata see the id they asked for, not whichever provider
+  // happened to be requested first.
+  const cacheKey = useMockProvider() ? `${MOCK_PREFIX}${providerType}` : providerType;
+  const cached = instances.get(cacheKey);
+  if (cached) return cached;
 
-  // NODE_ENV=test always uses mock regardless of PAYMENT_PROVIDER setting
-  if (name === 'mock' || env.NODE_ENV === 'test') {
+  let instance: IPaymentProvider;
+  if (useMockProvider()) {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { MockPaymentProvider } = require('./providers/mock/mockProvider');
-    _provider = new MockPaymentProvider();
-  } else if (name === 'stripe') {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { StripePaymentProvider } = require('./providers/stripe');
-    _provider = new StripePaymentProvider();
+    instance = new MockPaymentProvider(providerType);
   } else {
-    throw new Error(`Unknown payment provider: "${name}". Valid values: stripe, mock`);
+    switch (providerType) {
+      case PaymentProvider.STRIPE: {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { StripePaymentProvider } = require('./providers/stripe');
+        instance = new StripePaymentProvider();
+        break;
+      }
+      default:
+        throw new Error(`Unsupported payment provider: ${providerType}`);
+    }
   }
 
-  return _provider!;
+  instances.set(cacheKey, instance);
+  return instance;
 }
 
 export function resetPaymentProvider(): void {
-  _provider = null;
+  instances.clear();
+}
+
+function isMissingRecord(err: unknown): boolean {
+  return err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025';
+}
+
+/** Look up the user's paymentProvider and return its provider instance. */
+export async function getProviderForUser(userId: string): Promise<IPaymentProvider> {
+  try {
+    const user = await prisma.user.findUniqueOrThrow({
+      where: { id: userId },
+      select: { paymentProvider: true },
+    });
+    return getPaymentProvider(user.paymentProvider);
+  } catch (err) {
+    if (isMissingRecord(err)) throw new UserNotFoundError(userId);
+    throw err;
+  }
+}
+
+/** Look up the intent's user and return its provider instance. */
+export async function getProviderForIntent(intentId: string): Promise<IPaymentProvider> {
+  try {
+    const intent = await prisma.purchaseIntent.findUniqueOrThrow({
+      where: { id: intentId },
+      select: { user: { select: { paymentProvider: true } } },
+    });
+    return getPaymentProvider(intent.user.paymentProvider);
+  } catch (err) {
+    if (isMissingRecord(err)) throw new IntentNotFoundError(intentId);
+    throw err;
+  }
 }

--- a/src/payments/providers/mock/mockProvider.ts
+++ b/src/payments/providers/mock/mockProvider.ts
@@ -1,10 +1,24 @@
-import { IPaymentProvider, IssuingBalance, VirtualCardData, CardReveal } from '@/contracts';
+import {
+  IPaymentProvider,
+  IssuingBalance,
+  VirtualCardData,
+  CardReveal,
+  ProviderMetadata,
+  PaymentProvider,
+} from '@/contracts';
 
 type CallRecord = { method: string; args: unknown[]; timestamp: number };
 
 export class MockPaymentProvider implements IPaymentProvider {
+  readonly metadata: ProviderMetadata;
   private calls: CallRecord[] = [];
   private issuingBalance = 999_999_99;
+
+  // Reflect the requested provider type so callers branching on
+  // provider.metadata.id see the id they asked for in tests.
+  constructor(providerType: PaymentProvider = PaymentProvider.STRIPE) {
+    this.metadata = { id: providerType, currency: 'eur' };
+  }
 
   getCalls(): CallRecord[] {
     return [...this.calls];
@@ -17,18 +31,18 @@ export class MockPaymentProvider implements IPaymentProvider {
   async issueCard(
     intentId: string,
     amount: number,
-    currency: string,
     options?: { mccAllowlist?: string[] },
   ): Promise<VirtualCardData> {
     this.calls.push({
       method: 'issueCard',
-      args: [intentId, amount, currency, options],
+      args: [intentId, amount, options],
       timestamp: Date.now(),
     });
     return {
       id: `mock-card-${intentId}`,
       intentId,
-      stripeCardId: `mock_stripe_${intentId}`,
+      provider: this.metadata.id,
+      providerCardId: `mock_provider_${intentId}`,
       last4: '4242',
       revealedAt: null,
       frozenAt: null,
@@ -62,9 +76,9 @@ export class MockPaymentProvider implements IPaymentProvider {
     return { received: true };
   }
 
-  async getIssuingBalance(currency: string): Promise<IssuingBalance> {
-    this.calls.push({ method: 'getIssuingBalance', args: [currency], timestamp: Date.now() });
-    return { available: this.issuingBalance, currency: currency.toLowerCase() };
+  async getIssuingBalance(): Promise<IssuingBalance> {
+    this.calls.push({ method: 'getIssuingBalance', args: [], timestamp: Date.now() });
+    return { available: this.issuingBalance, currency: this.metadata.currency };
   }
 
   setIssuingBalance(amount: number): void {

--- a/src/payments/providers/stripe/cardService.ts
+++ b/src/payments/providers/stripe/cardService.ts
@@ -7,6 +7,7 @@ import {
   CardReveal,
   CardAlreadyRevealedError,
   IntentNotFoundError,
+  PaymentProvider,
 } from '@/contracts';
 import { logger } from '@/config/logger';
 
@@ -33,8 +34,8 @@ export async function issueVirtualCard(
   // Upsert cardholder: reuse existing Stripe cardholder if the user already has one,
   // otherwise create a new one and persist the ID so future intents reuse it.
   let cardholderId: string;
-  if (intent.user.stripeCardholderId) {
-    cardholderId = intent.user.stripeCardholderId;
+  if (intent.user.providerCardholderId) {
+    cardholderId = intent.user.providerCardholderId;
   } else {
     let newCardholder: Stripe.Issuing.Cardholder;
     try {
@@ -67,7 +68,7 @@ export async function issueVirtualCard(
     // Persist so all future intents for this user reuse the same cardholder
     await prisma.user.update({
       where: { id: intent.user.id },
-      data: { stripeCardholderId: cardholderId },
+      data: { providerCardholderId: cardholderId },
     });
   }
 
@@ -97,11 +98,12 @@ export async function issueVirtualCard(
     throw err;
   }
 
-  // Persist ONLY stripeCardId + last4 — never PAN, CVC
+  // Persist ONLY providerCardId + last4 — never PAN, CVC
   const virtualCard = await prisma.virtualCard.create({
     data: {
       intentId,
-      stripeCardId: stripeCard.id,
+      provider: PaymentProvider.STRIPE,
+      providerCardId: stripeCard.id,
       last4: stripeCard.last4,
     },
   });
@@ -119,7 +121,7 @@ export async function revealCard(intentId: string): Promise<CardReveal> {
   // Retrieve card with expanded number and CVC (test mode only)
   let stripeCard: Stripe.Issuing.Card;
   try {
-    stripeCard = await stripe.issuing.cards.retrieve(card.stripeCardId, {
+    stripeCard = await stripe.issuing.cards.retrieve(card.providerCardId, {
       expand: ['number', 'cvc'],
     });
   } catch (err) {
@@ -154,7 +156,7 @@ export async function freezeCard(intentId: string): Promise<void> {
   if (!card) throw new IntentNotFoundError(intentId);
 
   try {
-    await stripe.issuing.cards.update(card.stripeCardId, { status: 'inactive' });
+    await stripe.issuing.cards.update(card.providerCardId, { status: 'inactive' });
   } catch (err) {
     if (err instanceof Stripe.errors.StripeError) {
       log.error({ intentId, type: err.type, code: err.code, err }, 'Failed to freeze card');
@@ -177,7 +179,7 @@ export async function cancelCard(intentId: string): Promise<void> {
 
   const stripe = getStripeClient();
   try {
-    await stripe.issuing.cards.update(card.stripeCardId, { status: 'canceled' });
+    await stripe.issuing.cards.update(card.providerCardId, { status: 'canceled' });
   } catch (err) {
     if (err instanceof Stripe.errors.StripeError) {
       // Guard 2: card was already cancelled externally (e.g. Stripe dashboard)

--- a/src/payments/providers/stripe/checkoutSimulator.ts
+++ b/src/payments/providers/stripe/checkoutSimulator.ts
@@ -24,14 +24,14 @@ export async function runSimulatedCheckout(params: {
   const stripe = getStripeClient();
   const { intentId, amount, currency, merchantName } = params;
 
-  // Look up stripeCardId from DB — no raw card data needed
+  // Look up providerCardId from DB — no raw card data needed
   const virtualCard = await prisma.virtualCard.findUnique({ where: { intentId } });
   if (!virtualCard) throw new IntentNotFoundError(intentId);
 
   let auth: Stripe.Issuing.Authorization;
   try {
     auth = await stripe.testHelpers.issuing.authorizations.create({
-      card: virtualCard.stripeCardId,
+      card: virtualCard.providerCardId,
       amount,
       currency: currency.toLowerCase(),
       merchant_data: { name: merchantName },

--- a/src/payments/providers/stripe/index.ts
+++ b/src/payments/providers/stripe/index.ts
@@ -1,16 +1,29 @@
-import { IPaymentProvider, IssuingBalance, VirtualCardData, CardReveal } from '@/contracts';
+import {
+  IPaymentProvider,
+  IssuingBalance,
+  VirtualCardData,
+  CardReveal,
+  ProviderMetadata,
+  PaymentProvider,
+} from '@/contracts';
 import { issueVirtualCard, revealCard, freezeCard, cancelCard } from './cardService';
 import { getIssuingBalance as fetchIssuingBalance } from './balanceService';
 import { handleStripeEvent } from './webhookHandler';
 
+const METADATA: ProviderMetadata = {
+  id: PaymentProvider.STRIPE,
+  currency: 'eur',
+};
+
 export class StripePaymentProvider implements IPaymentProvider {
+  readonly metadata = METADATA;
+
   async issueCard(
     intentId: string,
     amount: number,
-    currency: string,
     options?: { mccAllowlist?: string[] },
   ): Promise<VirtualCardData> {
-    return issueVirtualCard(intentId, amount, currency, options);
+    return issueVirtualCard(intentId, amount, this.metadata.currency, options);
   }
 
   async revealCard(intentId: string): Promise<CardReveal> {
@@ -32,7 +45,7 @@ export class StripePaymentProvider implements IPaymentProvider {
     return handleStripeEvent(rawBody, signature);
   }
 
-  async getIssuingBalance(currency: string): Promise<IssuingBalance> {
-    return fetchIssuingBalance(currency);
+  async getIssuingBalance(): Promise<IssuingBalance> {
+    return fetchIssuingBalance(this.metadata.currency);
   }
 }

--- a/src/payments/providers/stripe/reconciliationService.ts
+++ b/src/payments/providers/stripe/reconciliationService.ts
@@ -1,6 +1,12 @@
 import { getStripeClient } from './stripeClient';
 import { prisma } from '@/db/client';
+import { logger } from '@/config/logger';
 import type { ReconciliationReport } from '@/contracts';
+
+const log = logger.child({ module: 'payments/stripe/reconciliationService' });
+
+// Safety cap for stripe.issuing.transactions.list pagination.
+const MAX_TRANSACTIONS = 1000;
 
 export async function reconcileIntent(intentId: string): Promise<ReconciliationReport> {
   const pot = await prisma.pot.findUnique({ where: { intentId } });
@@ -15,24 +21,73 @@ export async function reconcileIntent(intentId: string): Promise<ReconciliationR
   };
 
   if (!card) {
-    return { intentId, internal, stripe: null, inSync: true, discrepancies: [] };
+    const discrepancies: string[] = [];
+    const moneyMoved =
+      pot !== null &&
+      (pot.settledAmount > 0 || pot.status === 'SETTLED' || pot.status === 'RETURNED');
+    if (moneyMoved) {
+      discrepancies.push(
+        `virtualCard missing for intent with pot status ${pot!.status} (settledAmount ${pot!.settledAmount})`,
+      );
+    }
+    return {
+      intentId,
+      internal,
+      stripe: null,
+      inSync: discrepancies.length === 0,
+      discrepancies,
+    };
   }
 
   const stripe = getStripeClient();
-  const stripeCard = await stripe.issuing.cards.retrieve(card.stripeCardId);
-  const txList = await stripe.issuing.transactions.list({
-    card: card.stripeCardId,
-    type: 'capture',
-  });
 
-  const totalCaptured = txList.data.reduce((sum, t) => sum + t.amount, 0);
+  let stripeCard;
+  let transactions;
+  try {
+    stripeCard = await stripe.issuing.cards.retrieve(card.providerCardId);
+    transactions = await stripe.issuing.transactions
+      .list({ card: card.providerCardId })
+      .autoPagingToArray({ limit: MAX_TRANSACTIONS });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.error(
+      { intentId, providerCardId: card.providerCardId, err },
+      'Stripe API call failed during reconciliation',
+    );
+    return {
+      intentId,
+      internal,
+      stripe: null,
+      inSync: false,
+      discrepancies: [`stripe API error: ${message}`],
+    };
+  }
+
+  // Net captured: Stripe Issuing captures are negative; refunds are positive.
+  let totalCaptured = 0;
+  for (const t of transactions) {
+    const abs = Math.abs(t.amount);
+    if (t.type === 'refund') {
+      totalCaptured -= abs;
+    } else {
+      totalCaptured += abs;
+    }
+  }
+
   const stripeReport = {
     cardStatus: stripeCard.status,
-    transactions: txList.data.map((t) => ({ id: t.id, amount: t.amount, type: t.type })),
+    transactions: transactions.map((t) => ({ id: t.id, amount: t.amount, type: t.type })),
     totalCaptured,
   };
 
   const discrepancies: string[] = [];
+
+  if (transactions.length >= MAX_TRANSACTIONS) {
+    discrepancies.push(
+      `stripe transactions truncated at ${MAX_TRANSACTIONS} — totalCaptured may be incomplete`,
+    );
+  }
+
   if (pot !== null && pot.settledAmount !== totalCaptured) {
     discrepancies.push(`settledAmount ${pot.settledAmount} != stripe captured ${totalCaptured}`);
   }

--- a/src/payments/providers/stripe/webhookHandler.ts
+++ b/src/payments/providers/stripe/webhookHandler.ts
@@ -1,8 +1,8 @@
 import Stripe from 'stripe';
 import { getStripeClient } from './stripeClient';
+import { cancelCard } from './cardService';
 import { prisma } from '@/db/client';
 import { reconcileIntent } from './reconciliationService';
-import { getPaymentProvider } from '@/payments';
 import { logger } from '@/config/logger';
 
 const log = logger.child({ module: 'payments/stripe/webhookHandler' });
@@ -60,11 +60,9 @@ export async function handleStripeEvent(
         include: { user: { select: { cancelPolicy: true } } },
       });
       if (intentForPolicy?.user?.cancelPolicy === 'ON_TRANSACTION') {
-        getPaymentProvider()
-          .cancelCard(intentId)
-          .catch((err) => {
-            log.error({ intentId, err }, 'ON_TRANSACTION card cancel failed');
-          });
+        cancelCard(intentId).catch((err) => {
+          log.error({ intentId, err }, 'ON_TRANSACTION card cancel failed');
+        });
       }
 
       // Fire-and-forget reconciliation — discrepancy failure must not break webhook

--- a/src/payments/testHelpers.ts
+++ b/src/payments/testHelpers.ts
@@ -2,6 +2,7 @@
  * Test-only helpers for the payments module.
  * Import these only in test files — never in production code.
  */
+import { PaymentProvider } from '@/contracts';
 import { MockPaymentProvider } from './providers/mock/mockProvider';
 import { StripePaymentProvider } from './providers/stripe';
 import { getStripeClient } from './providers/stripe/stripeClient';
@@ -21,7 +22,7 @@ export function createStripeProvider() {
 }
 
 export function getMockProvider(): MockPaymentProvider {
-  const provider = getPaymentProvider();
+  const provider = getPaymentProvider(PaymentProvider.STRIPE);
   if (!(provider instanceof MockPaymentProvider)) {
     throw new Error('getMockProvider() called but active provider is not MockPaymentProvider');
   }

--- a/src/telegram/callbackHandler.ts
+++ b/src/telegram/callbackHandler.ts
@@ -1,6 +1,12 @@
 import type { Update } from 'grammy/types';
 import { prisma } from '@/db/client';
-import { ApprovalDecisionType, IntentStatus, InsufficientIssuingBalanceError } from '@/contracts';
+import {
+  ApprovalDecisionType,
+  IntentStatus,
+  InsufficientIssuingBalanceError,
+  IntentNotFoundError,
+  UserNotFoundError,
+} from '@/contracts';
 import { recordDecision } from '@/approval/approvalService';
 import { reserveForIntent, returnIntent } from '@/ledger/potService';
 import { getPaymentProvider } from '@/payments';
@@ -122,14 +128,15 @@ export async function handleTelegramCallback(update: Update): Promise<void> {
   try {
     if (action === 'approve') {
       const metadata = intent.metadata as Record<string, unknown>;
+      const provider = getPaymentProvider(intent.user.paymentProvider);
 
-      // Check Stripe Issuing balance BEFORE persisting the decision
-      const issuingBalance = await getPaymentProvider().getIssuingBalance(intent.currency);
+      // Check issuing balance BEFORE persisting the decision
+      const issuingBalance = await provider.getIssuingBalance();
       if (issuingBalance.available < intent.maxBudget) {
         throw new InsufficientIssuingBalanceError(
           issuingBalance.available,
           intent.maxBudget,
-          intent.currency,
+          issuingBalance.currency,
         );
       }
 
@@ -138,7 +145,7 @@ export async function handleTelegramCallback(update: Update): Promise<void> {
 
       let card;
       try {
-        card = await getPaymentProvider().issueCard(intentId, intent.maxBudget, intent.currency, {
+        card = await provider.issueCard(intentId, intent.maxBudget, {
           mccAllowlist: intent.user.mccAllowlist,
         });
       } catch (cardErr) {
@@ -155,7 +162,7 @@ export async function handleTelegramCallback(update: Update): Promise<void> {
         merchantUrl: (metadata.merchantUrl as string) ?? '',
         price: (metadata.price as number) ?? intent.maxBudget,
         currency: intent.currency,
-        stripeCardId: card.stripeCardId,
+        providerCardId: card.providerCardId,
         last4: card.last4,
       });
 
@@ -171,6 +178,19 @@ export async function handleTelegramCallback(update: Update): Promise<void> {
         chatId,
         messageId,
         `⚠️ Insufficient Stripe Issuing balance (${err.currency}): available ${err.available}, required ${err.required}.`,
+      );
+      return;
+    }
+    // Race conditions only — the intent and user were both verified at the
+    // top of this handler. Show a friendly message and don't rethrow so the
+    // Telegram webhook returns 200 (otherwise grammy retries the update).
+    if (err instanceof IntentNotFoundError || err instanceof UserNotFoundError) {
+      log.warn({ intentId, action, actorId, err }, 'Approval target disappeared mid-flow');
+      await editMessage(
+        bot,
+        chatId,
+        messageId,
+        '⚠️ This intent is no longer available. It may have expired or been cancelled.',
       );
       return;
     }

--- a/src/telegram/menuHandler.ts
+++ b/src/telegram/menuHandler.ts
@@ -2,7 +2,7 @@ import { InlineKeyboard } from 'grammy';
 import { prisma } from '@/db/client';
 import { getTelegramBot } from './telegramClient';
 import { expireIntent } from '@/orchestrator/intentService';
-import { getPaymentProvider } from '@/payments';
+import { getProviderForIntent } from '@/payments';
 import { IntentStatus, CardCancelPolicy } from '@/contracts';
 import { setPrefSession } from './sessionStore';
 
@@ -321,7 +321,8 @@ async function doCancelCard(
   intentId: string,
 ): Promise<void> {
   try {
-    await getPaymentProvider().cancelCard(intentId);
+    const provider = await getProviderForIntent(intentId);
+    await provider.cancelCard(intentId);
     const keyboard = new InlineKeyboard().text('⬅️ Back to Menu', 'menu_main:_');
     await editMenu(bot, chatId, messageId, '✅ Card cancelled successfully.', keyboard);
   } catch {

--- a/src/worker/processors/cancelCardProcessor.ts
+++ b/src/worker/processors/cancelCardProcessor.ts
@@ -1,6 +1,6 @@
 import { Worker, Job } from 'bullmq';
 import { getRedisConnectionConfig } from '@/config/redis';
-import { getPaymentProvider } from '@/payments';
+import { getProviderForIntent } from '@/payments';
 import { logger } from '@/config/logger';
 
 const log = logger.child({ module: 'worker/processors/cancelCardProcessor' });
@@ -16,7 +16,8 @@ export function createCancelCardWorker(): Worker {
       const { intentId } = job.data;
       log.info({ intentId }, 'Processing cancel card job');
 
-      await getPaymentProvider().cancelCard(intentId);
+      const provider = await getProviderForIntent(intentId);
+      await provider.cancelCard(intentId);
 
       log.info({ intentId }, 'Card cancelled via AFTER_TTL policy');
     },

--- a/tests/integration/e2e/cardLifecycle.test.ts
+++ b/tests/integration/e2e/cardLifecycle.test.ts
@@ -111,7 +111,7 @@ testSuite('Card lifecycle integration', () => {
 
         await issueVirtualCard(intentId, 1_000, 'eur');
         const card = await prisma.virtualCard.findUniqueOrThrow({ where: { intentId } });
-        stripeCardId = card.stripeCardId;
+        stripeCardId = card.providerCardId;
 
         // Stripe test mode needs ~3-5s for cardholder verification to settle;
         // without this wait, authorizations are declined with cardholder_verification_required
@@ -214,7 +214,7 @@ testSuite('Card lifecycle integration', () => {
 
         await issueVirtualCard(intentId, 1_000, 'eur');
         const card = await prisma.virtualCard.findUniqueOrThrow({ where: { intentId } });
-        stripeCardId = card.stripeCardId;
+        stripeCardId = card.providerCardId;
 
         await new Promise((r) => setTimeout(r, 5_000));
       } catch (err) {

--- a/tests/integration/e2e/checkoutSimulator.test.ts
+++ b/tests/integration/e2e/checkoutSimulator.test.ts
@@ -102,10 +102,10 @@ testSuite('Stripe Issuing card lifecycle + checkout simulation', () => {
     intentId = intent.id;
 
     // Issue the virtual card via Stripe Issuing (real API call)
-    await stripeCtx.provider.issueCard(intentId, 100, 'eur');
+    await stripeCtx.provider.issueCard(intentId, 100);
 
     const card = await prisma.virtualCard.findUniqueOrThrow({ where: { intentId } });
-    stripeCardId = card.stripeCardId;
+    stripeCardId = card.providerCardId;
 
     // Reveal credentials once — stored for all tests in this suite
     const reveal = await stripeCtx.provider.revealCard(intentId);
@@ -127,10 +127,10 @@ testSuite('Stripe Issuing card lifecycle + checkout simulation', () => {
   // ─── 1. Card issuance + reveal ──────────────────────────────────────────────
 
   describe('card issuance and reveal', () => {
-    it('persists the card in DB with stripeCardId and last4 (no PAN/CVC stored)', async () => {
+    it('persists the card in DB with providerCardId and last4 (no PAN/CVC stored)', async () => {
       const card = await prisma.virtualCard.findUnique({ where: { intentId } });
       expect(card).not.toBeNull();
-      expect(card!.stripeCardId).toMatch(/^ic_/);
+      expect(card!.providerCardId).toMatch(/^ic_/);
       expect(card!.last4).toHaveLength(4);
       expect(card!.revealedAt).not.toBeNull();
       // Confirm PAN is not in the DB row

--- a/tests/integration/e2e/errorPaths.test.ts
+++ b/tests/integration/e2e/errorPaths.test.ts
@@ -45,17 +45,20 @@ const mockCancelCard = jest.fn().mockResolvedValue(undefined);
 const mockIssueCard = jest.fn().mockResolvedValue({
   id: 'vc-1',
   intentId: 'i1',
-  stripeCardId: 'ic_test',
+  providerCardId: 'ic_test',
   last4: '4242',
 });
+const mockProvider = {
+  issueCard: mockIssueCard,
+  revealCard: mockRevealCard,
+  freezeCard: jest.fn().mockResolvedValue(undefined),
+  cancelCard: mockCancelCard,
+  handleWebhookEvent: jest.fn().mockResolvedValue(undefined),
+};
 jest.mock('@/payments', () => ({
-  getPaymentProvider: () => ({
-    issueCard: mockIssueCard,
-    revealCard: mockRevealCard,
-    freezeCard: jest.fn().mockResolvedValue(undefined),
-    cancelCard: mockCancelCard,
-    handleWebhookEvent: jest.fn().mockResolvedValue(undefined),
-  }),
+  getPaymentProvider: () => mockProvider,
+  getProviderForIntent: () => Promise.resolve(mockProvider),
+  getProviderForUser: () => Promise.resolve(mockProvider),
 }));
 
 const mockDb = {

--- a/tests/integration/e2e/telegramApprovalCheckout.test.ts
+++ b/tests/integration/e2e/telegramApprovalCheckout.test.ts
@@ -165,7 +165,7 @@ testSuite('Telegram approval -> Stripe Issuing checkout', () => {
         // Mock mode: skip the 60 s wait and auto-approve immediately
         await recordDecision(intentId, ApprovalDecisionType.APPROVED, 'test-mock-approve');
         await reserveForIntent(userId, intentId, MAX_BUDGET);
-        await stripeCtx.provider.issueCard(intentId, MAX_BUDGET, CURRENCY);
+        await stripeCtx.provider.issueCard(intentId, MAX_BUDGET);
         await markCardIssued(intentId);
         await startCheckout(intentId);
 
@@ -205,7 +205,7 @@ testSuite('Telegram approval -> Stripe Issuing checkout', () => {
         console.log('Timeout -- auto-approving and continuing...');
         await recordDecision(intentId, ApprovalDecisionType.APPROVED, 'test-auto-approve');
         await reserveForIntent(userId, intentId, MAX_BUDGET);
-        await stripeCtx.provider.issueCard(intentId, MAX_BUDGET, CURRENCY);
+        await stripeCtx.provider.issueCard(intentId, MAX_BUDGET);
         await markCardIssued(intentId);
         await startCheckout(intentId);
         currentStatus = IntentStatus.CHECKOUT_RUNNING;
@@ -225,10 +225,10 @@ testSuite('Telegram approval -> Stripe Issuing checkout', () => {
   // -- Step 5 -- Verify card was issued ---------------------------------------
   it('has a real Stripe Issuing card in the database', async () => {
     const card = await prisma.virtualCard.findUniqueOrThrow({ where: { intentId } });
-    expect(card.stripeCardId).toMatch(/^ic_/);
+    expect(card.providerCardId).toMatch(/^ic_/);
     expect(card.last4).toHaveLength(4);
 
-    const stripeCard = await stripeCtx.stripe.issuing.cards.retrieve(card.stripeCardId);
+    const stripeCard = await stripeCtx.stripe.issuing.cards.retrieve(card.providerCardId);
     expect(stripeCard.status).toBe('active');
     expect(stripeCard.spending_controls.spending_limits[0].amount).toBe(MAX_BUDGET);
 
@@ -247,7 +247,7 @@ testSuite('Telegram approval -> Stripe Issuing checkout', () => {
     const card = await prisma.virtualCard.findUniqueOrThrow({ where: { intentId } });
 
     const auth = await stripeCtx.stripe.testHelpers.issuing.authorizations.create({
-      card: card.stripeCardId,
+      card: card.providerCardId,
       amount: CHECKOUT_AMOUNT,
       currency: CURRENCY,
       merchant_data: { name: MERCHANT_NAME },

--- a/tests/integration/stripe/reconciliation.test.ts
+++ b/tests/integration/stripe/reconciliation.test.ts
@@ -8,9 +8,11 @@
  *   npm run test:integration -- --testPathPattern=reconciliation
  */
 
+import crypto from 'crypto';
 import Stripe from 'stripe';
 import { prisma } from '@/db/client';
 import { reconcileIntent } from '@/payments/providers/stripe/reconciliationService';
+import { PaymentProvider } from '@/contracts';
 
 const STRIPE_KEY = process.env.STRIPE_SECRET_KEY;
 const describeIfStripe =
@@ -25,12 +27,11 @@ describeIfStripe('Reconciliation integration', () => {
   beforeAll(async () => {
     stripe = new Stripe(STRIPE_KEY!, { apiVersion: '2024-06-20' as Stripe.LatestApiVersion });
 
-    // Create minimal DB records
     const user = await prisma.user.create({
       data: {
         email: `recon-test-${Date.now()}@example.com`,
         telegramChatId: null,
-        stripeCardholderId: null,
+        providerCardholderId: null,
       },
     });
     userId = user.id;
@@ -40,13 +41,13 @@ describeIfStripe('Reconciliation integration', () => {
         userId,
         query: 'reconciliation test product',
         maxBudget: 5000,
-        currency: 'gbp',
+        currency: 'eur',
         status: 'DONE',
+        idempotencyKey: `recon-test-${crypto.randomUUID()}`,
       },
     });
     intentId = intent.id;
 
-    // Create Stripe cardholder and card
     const cardholder = await stripe.issuing.cardholders.create({
       name: 'Recon Test',
       email: `recon-stripe-${Date.now()}@example.com`,
@@ -74,39 +75,47 @@ describeIfStripe('Reconciliation integration', () => {
     });
     cardId = card.id;
 
-    // Write VirtualCard to DB
     await prisma.virtualCard.create({
-      data: { intentId, stripeCardId: cardId, last4: card.last4 },
+      data: {
+        intentId,
+        provider: PaymentProvider.STRIPE,
+        providerCardId: cardId,
+        last4: card.last4,
+      },
     });
 
-    // Simulate a capture
-    const auth = await stripe.testHelpers.issuing.authorizations.create({
+    await stripe.testHelpers.issuing.transactions.createForceCapture({
       card: cardId,
       amount: 3500,
       currency: 'eur',
       merchant_data: { name: 'Test Merchant' },
     });
-    await stripe.testHelpers.issuing.authorizations.capture(auth.id);
 
-    // Cancel the card (mirrors what the system does post-checkout)
     await stripe.issuing.cards.update(cardId, { status: 'canceled' });
 
-    // Write matching ledger records
     await prisma.pot.create({
-      data: { intentId, reservedAmount: 5000, settledAmount: 3500, status: 'SETTLED' },
+      data: {
+        userId,
+        intentId,
+        reservedAmount: 5000,
+        settledAmount: 3500,
+        status: 'SETTLED',
+      },
     });
     await prisma.ledgerEntry.create({
-      data: { intentId, type: 'RESERVE', amount: 5000 },
+      data: { userId, intentId, type: 'RESERVE', amount: 5000 },
     });
     await prisma.ledgerEntry.create({
-      data: { intentId, type: 'SETTLE', amount: 3500 },
+      data: { userId, intentId, type: 'SETTLE', amount: 3500 },
     });
   }, 60_000);
 
   afterAll(async () => {
-    // Clean up DB records (cascade delete via purchaseIntent)
-    await prisma.purchaseIntent.delete({ where: { id: intentId } }).catch(() => {});
-    await prisma.user.delete({ where: { id: userId } }).catch(() => {});
+    await prisma.ledgerEntry.deleteMany({ where: { intentId } }).catch(() => {});
+    await prisma.pot.deleteMany({ where: { intentId } }).catch(() => {});
+    await prisma.virtualCard.deleteMany({ where: { intentId } }).catch(() => {});
+    await prisma.purchaseIntent.deleteMany({ where: { id: intentId } }).catch(() => {});
+    await prisma.user.deleteMany({ where: { id: userId } }).catch(() => {});
     await prisma.$disconnect();
   });
 
@@ -120,7 +129,6 @@ describeIfStripe('Reconciliation integration', () => {
   });
 
   it('returns inSync:false with discrepancy when settledAmount is wrong', async () => {
-    // Corrupt the pot
     await prisma.pot.update({
       where: { intentId },
       data: { settledAmount: 9999 },
@@ -131,7 +139,6 @@ describeIfStripe('Reconciliation integration', () => {
     expect(report.inSync).toBe(false);
     expect(report.discrepancies.some((d) => d.includes('9999'))).toBe(true);
 
-    // Restore
     await prisma.pot.update({
       where: { intentId },
       data: { settledAmount: 3500 },

--- a/tests/unit/api/rateLimit.test.ts
+++ b/tests/unit/api/rateLimit.test.ts
@@ -60,12 +60,13 @@ jest.mock('@/ledger/potService', () => ({
   returnIntent: jest.fn().mockResolvedValue(undefined),
 }));
 
-jest.mock('@/payments', () => ({
-  getPaymentProvider: () => ({
+jest.mock('@/payments', () => {
+  const mockProvider = {
+    metadata: { id: 'STRIPE', currency: 'eur' },
     issueCard: jest.fn().mockResolvedValue({
       id: 'vc-1',
       intentId: 'intent-1',
-      stripeCardId: 'ic_test',
+      providerCardId: 'ic_test',
       last4: '4242',
     }),
     revealCard: jest.fn().mockResolvedValue({
@@ -78,8 +79,14 @@ jest.mock('@/payments', () => ({
     freezeCard: jest.fn().mockResolvedValue(undefined),
     cancelCard: jest.fn().mockResolvedValue(undefined),
     handleWebhookEvent: jest.fn().mockResolvedValue(undefined),
-  }),
-}));
+    getIssuingBalance: jest.fn().mockResolvedValue({ available: 999_999_99, currency: 'eur' }),
+  };
+  return {
+    getPaymentProvider: () => mockProvider,
+    getProviderForIntent: () => Promise.resolve(mockProvider),
+    getProviderForUser: () => Promise.resolve(mockProvider),
+  };
+});
 
 jest.mock('@/payments/providers/stripe/stripeClient', () => ({
   getStripeClient: () => ({ webhooks: { constructEvent: jest.fn() } }),
@@ -122,6 +129,7 @@ const dbUsers: Record<string, any> = {
     mccAllowlist: [],
     apiKeyHash: null,
     apiKeyPrefix: TEST_KEY_PREFIX,
+    paymentProvider: 'STRIPE',
   },
 };
 const dbIntents: Record<string, any> = {};

--- a/tests/unit/api/wiring.test.ts
+++ b/tests/unit/api/wiring.test.ts
@@ -81,7 +81,7 @@ jest.mock('@/ledger/potService', () => ({
 const mockIssueVirtualCard = jest.fn().mockResolvedValue({
   id: 'vc-1',
   intentId: 'intent-1',
-  stripeCardId: 'ic_test',
+  providerCardId: 'ic_test',
   last4: '4242',
 });
 const mockRevealCard = jest.fn().mockResolvedValue({
@@ -94,8 +94,9 @@ const mockRevealCard = jest.fn().mockResolvedValue({
 const mockCancelCard = jest.fn().mockResolvedValue(undefined);
 const mockGetIssuingBalance = jest
   .fn()
-  .mockResolvedValue({ available: 999_999_99, currency: 'gbp' });
+  .mockResolvedValue({ available: 999_999_99, currency: 'eur' });
 const mockPaymentProvider = {
+  metadata: { id: 'STRIPE', currency: 'eur' },
   issueCard: mockIssueVirtualCard,
   revealCard: mockRevealCard,
   freezeCard: jest.fn().mockResolvedValue(undefined),
@@ -105,6 +106,8 @@ const mockPaymentProvider = {
 };
 jest.mock('@/payments', () => ({
   getPaymentProvider: () => mockPaymentProvider,
+  getProviderForIntent: () => Promise.resolve(mockPaymentProvider),
+  getProviderForUser: () => Promise.resolve(mockPaymentProvider),
 }));
 
 // Stripe (needed by webhooks route import chain)
@@ -134,6 +137,7 @@ const dbUsers: Record<string, any> = {
     mccAllowlist: [],
     apiKeyHash: null,
     apiKeyPrefix: TEST_KEY_PREFIX,
+    paymentProvider: 'STRIPE',
   },
 };
 const dbIntents: Record<string, any> = {};
@@ -299,7 +303,7 @@ describe('POST /v1/intents wiring', () => {
       userId: 'user-1',
       query: 'Sony headphones',
       maxBudget: 30000,
-      currency: 'gbp',
+      currency: 'eur',
     });
     expect(payload.intentId).toBe(intentId);
   });
@@ -415,9 +419,14 @@ describe('POST /v1/approvals/:id/decision wiring — APPROVED', () => {
       userId: 'user-1',
       status: IntentStatus.AWAITING_APPROVAL,
       maxBudget: 10000,
-      currency: 'gbp',
+      currency: 'eur',
       metadata: { merchantName: 'Amazon UK', merchantUrl: 'https://amazon.co.uk', price: 9999 },
-      user: { id: 'user-1', email: 'test@agentpay.dev', mccAllowlist: [] },
+      user: {
+        id: 'user-1',
+        email: 'test@agentpay.dev',
+        mccAllowlist: [],
+        paymentProvider: 'STRIPE',
+      },
     };
   }
 
@@ -474,12 +483,7 @@ describe('POST /v1/approvals/:id/decision wiring — APPROVED', () => {
       body: JSON.stringify({ decision: 'APPROVED', actorId: 'user-1' }),
     });
 
-    expect(mockIssueVirtualCard).toHaveBeenCalledWith(
-      'intent-a3',
-      10000,
-      'gbp',
-      expect.any(Object),
-    );
+    expect(mockIssueVirtualCard).toHaveBeenCalledWith('intent-a3', 10000, expect.any(Object));
   });
 
   it('calls markCardIssued and startCheckout via orchestrator', async () => {
@@ -519,7 +523,7 @@ describe('POST /v1/approvals/:id/decision wiring — APPROVED', () => {
       expect.objectContaining({
         intentId: 'intent-a5',
         userId: 'user-1',
-        stripeCardId: 'ic_test',
+        providerCardId: 'ic_test',
         last4: '4242',
       }),
     );
@@ -835,7 +839,7 @@ describe('GET /v1/agent/decision/:intentId wiring', () => {
   }
 
   function _makeCard(intentId: string, revealedAt: Date | null = null) {
-    return { id: 'vc-1', intentId, stripeCardId: 'ic_test', last4: '4242', revealedAt };
+    return { id: 'vc-1', intentId, providerCardId: 'ic_test', last4: '4242', revealedAt };
   }
 
   it('returns 401 without X-Worker-Key header', async () => {

--- a/tests/unit/ledger/potService.test.ts
+++ b/tests/unit/ledger/potService.test.ts
@@ -6,7 +6,7 @@ jest.mock('@/db/client', () => ({
 
 import { reserveForIntent, settleIntent, returnIntent } from '@/ledger/potService';
 import { prisma } from '@/db/client';
-import { InsufficientFundsError } from '@/contracts';
+import { InsufficientFundsError, IntentNotFoundError } from '@/contracts';
 
 const mockPrisma = prisma as jest.Mocked<typeof prisma>;
 
@@ -17,6 +17,11 @@ function makeTxMock(overrides: Record<string, any> = {}) {
     user: { findUnique: jest.fn(), update: jest.fn() },
     pot: { create: jest.fn(), findUnique: jest.fn(), update: jest.fn() },
     ledgerEntry: { create: jest.fn() },
+    purchaseIntent: {
+      // Default: intent belongs to 'user-1' so the ownership check in
+      // reserveForIntent passes for the common test setup.
+      findUnique: jest.fn().mockResolvedValue({ currency: 'eur', userId: 'user-1' }),
+    },
     ...overrides,
   };
 }
@@ -51,6 +56,51 @@ describe('reserveForIntent', () => {
         data: expect.objectContaining({ reservedAmount: 5000, status: 'ACTIVE' }),
       }),
     );
+  });
+
+  it('writes ledger entry with the currency fetched from the intent', async () => {
+    const tx = makeTxMock({
+      purchaseIntent: {
+        findUnique: jest.fn().mockResolvedValue({ currency: 'usd', userId: 'user-1' }),
+      },
+    });
+    tx.user.findUnique.mockResolvedValue({ id: 'user-1', mainBalance: 10000 });
+    tx.pot.create.mockResolvedValue({ id: 'pot-1', reservedAmount: 5000, status: 'ACTIVE' });
+    (mockPrisma.$transaction as jest.Mock).mockImplementation(async (fn: Function) => fn(tx));
+
+    await reserveForIntent('user-1', 'intent-1', 5000);
+
+    expect(tx.ledgerEntry.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ currency: 'usd' }),
+      }),
+    );
+  });
+
+  it('throws IntentNotFoundError when the intent does not exist', async () => {
+    const tx = makeTxMock({
+      purchaseIntent: { findUnique: jest.fn().mockResolvedValue(null) },
+    });
+    (mockPrisma.$transaction as jest.Mock).mockImplementation(async (fn: Function) => fn(tx));
+
+    await expect(reserveForIntent('user-1', 'intent-1', 1000)).rejects.toThrow(IntentNotFoundError);
+    expect(tx.user.findUnique).not.toHaveBeenCalled();
+    expect(tx.pot.create).not.toHaveBeenCalled();
+  });
+
+  it('throws IntentNotFoundError when the intent belongs to a different user', async () => {
+    const tx = makeTxMock({
+      purchaseIntent: {
+        findUnique: jest.fn().mockResolvedValue({ currency: 'eur', userId: 'someone-else' }),
+      },
+    });
+    (mockPrisma.$transaction as jest.Mock).mockImplementation(async (fn: Function) => fn(tx));
+
+    await expect(reserveForIntent('user-1', 'intent-1', 1000)).rejects.toThrow(IntentNotFoundError);
+    // Ownership check must short-circuit before any user lookup or writes.
+    expect(tx.user.findUnique).not.toHaveBeenCalled();
+    expect(tx.pot.create).not.toHaveBeenCalled();
+    expect(tx.ledgerEntry.create).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/orchestrator/expireCleanup.test.ts
+++ b/tests/unit/orchestrator/expireCleanup.test.ts
@@ -7,6 +7,8 @@ jest.mock('@/db/client', () => ({
 
 jest.mock('@/payments', () => ({
   getPaymentProvider: jest.fn(),
+  getProviderForIntent: jest.fn(),
+  getProviderForUser: jest.fn(),
 }));
 
 jest.mock('@/ledger/potService', () => ({
@@ -19,13 +21,13 @@ jest.mock('@/orchestrator/stateMachine', () => ({
 
 import { expireIntent } from '@/orchestrator/intentService';
 import { prisma } from '@/db/client';
-import { getPaymentProvider } from '@/payments';
+import { getProviderForIntent } from '@/payments';
 import { returnIntent } from '@/ledger/potService';
 import { transitionIntent } from '@/orchestrator/stateMachine';
 import { IntentStatus } from '@/contracts';
 
 const mockPrisma = prisma as jest.Mocked<typeof prisma>;
-const mockGetPaymentProvider = getPaymentProvider as jest.Mock;
+const mockGetProviderForIntent = getProviderForIntent as jest.Mock;
 const mockReturnIntent = returnIntent as jest.Mock;
 const mockTransitionIntent = transitionIntent as jest.Mock;
 
@@ -41,7 +43,7 @@ describe('expireIntent cleanup', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockCancelCard = jest.fn().mockResolvedValue(undefined);
-    mockGetPaymentProvider.mockReturnValue({ cancelCard: mockCancelCard });
+    mockGetProviderForIntent.mockResolvedValue({ cancelCard: mockCancelCard });
     mockTransitionIntent.mockResolvedValue(mockTransitionResult);
     mockReturnIntent.mockResolvedValue(undefined);
   });

--- a/tests/unit/orchestrator/postCheckoutCancelPolicy.test.ts
+++ b/tests/unit/orchestrator/postCheckoutCancelPolicy.test.ts
@@ -1,0 +1,116 @@
+jest.mock('@/db/client', () => ({
+  prisma: {
+    purchaseIntent: { findUnique: jest.fn() },
+  },
+}));
+
+jest.mock('@/payments', () => ({
+  getPaymentProvider: jest.fn(),
+  getProviderForIntent: jest.fn(),
+}));
+
+jest.mock('@/queue/producers', () => ({
+  enqueueCancelCard: jest.fn(),
+}));
+
+jest.mock('@/orchestrator/stateMachine', () => ({
+  transitionIntent: jest.fn(),
+}));
+
+jest.mock('@/telegram/telegramClient', () => ({
+  getTelegramBot: () => ({ api: { sendMessage: jest.fn() } }),
+}));
+
+import { completeCheckout } from '@/orchestrator/intentService';
+import { prisma } from '@/db/client';
+import { getPaymentProvider } from '@/payments';
+import { enqueueCancelCard } from '@/queue/producers';
+import { transitionIntent } from '@/orchestrator/stateMachine';
+import { IntentStatus, PaymentProvider } from '@/contracts';
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+const mockGetPaymentProvider = getPaymentProvider as jest.Mock;
+const mockEnqueueCancelCard = enqueueCancelCard as jest.Mock;
+const mockTransitionIntent = transitionIntent as jest.Mock;
+
+// Flush the fire-and-forget applyPostCheckoutCancelPolicy chain.
+const flush = () => new Promise<void>((r) => setImmediate(r));
+
+describe('completeCheckout — AFTER_TTL cancel policy', () => {
+  let mockCancelCard: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCancelCard = jest.fn().mockResolvedValue(undefined);
+    mockGetPaymentProvider.mockReturnValue({
+      cancelCard: mockCancelCard,
+      freezeCard: jest.fn(),
+    });
+    mockTransitionIntent.mockResolvedValue({
+      previousStatus: IntentStatus.CHECKOUT_RUNNING,
+      newStatus: IntentStatus.DONE,
+      intent: { id: 'intent-1', status: IntentStatus.DONE },
+    });
+  });
+
+  function intentWithUser(overrides: { cancelPolicy: string; cardTtlMinutes: number | null }) {
+    return {
+      id: 'intent-1',
+      user: {
+        cancelPolicy: overrides.cancelPolicy,
+        cardTtlMinutes: overrides.cardTtlMinutes,
+        telegramChatId: null,
+        paymentProvider: PaymentProvider.STRIPE,
+      },
+      virtualCard: { id: 'card-1' },
+    };
+  }
+
+  it('cancels immediately when cardTtlMinutes is 0 (does not enqueue a 0-delay job)', async () => {
+    (mockPrisma.purchaseIntent.findUnique as jest.Mock).mockResolvedValue(
+      intentWithUser({ cancelPolicy: 'AFTER_TTL', cardTtlMinutes: 0 }),
+    );
+
+    await completeCheckout('intent-1', 1000);
+    await flush();
+
+    expect(mockCancelCard).toHaveBeenCalledWith('intent-1');
+    expect(mockEnqueueCancelCard).not.toHaveBeenCalled();
+  });
+
+  it('cancels immediately when cardTtlMinutes is negative', async () => {
+    (mockPrisma.purchaseIntent.findUnique as jest.Mock).mockResolvedValue(
+      intentWithUser({ cancelPolicy: 'AFTER_TTL', cardTtlMinutes: -5 }),
+    );
+
+    await completeCheckout('intent-1', 1000);
+    await flush();
+
+    expect(mockCancelCard).toHaveBeenCalledWith('intent-1');
+    expect(mockEnqueueCancelCard).not.toHaveBeenCalled();
+  });
+
+  it('enqueues a delayed cancel when cardTtlMinutes is positive', async () => {
+    (mockPrisma.purchaseIntent.findUnique as jest.Mock).mockResolvedValue(
+      intentWithUser({ cancelPolicy: 'AFTER_TTL', cardTtlMinutes: 30 }),
+    );
+
+    await completeCheckout('intent-1', 1000);
+    await flush();
+
+    expect(mockEnqueueCancelCard).toHaveBeenCalledWith('intent-1', 30 * 60 * 1000);
+    expect(mockCancelCard).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when cardTtlMinutes is null even with AFTER_TTL policy', async () => {
+    (mockPrisma.purchaseIntent.findUnique as jest.Mock).mockResolvedValue(
+      intentWithUser({ cancelPolicy: 'AFTER_TTL', cardTtlMinutes: null }),
+    );
+
+    await completeCheckout('intent-1', 1000);
+    await flush();
+
+    expect(mockCancelCard).not.toHaveBeenCalled();
+    expect(mockEnqueueCancelCard).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/payments/cardService.test.ts
+++ b/tests/unit/payments/cardService.test.ts
@@ -35,19 +35,19 @@ import { CardAlreadyRevealedError, IntentNotFoundError } from '@/contracts';
 const mockPrisma = prisma as jest.Mocked<typeof prisma>;
 
 // Helper: a user with no pre-existing cardholder (first issuance)
-const newUser = { id: 'user-1', email: 'test@example.com', stripeCardholderId: null };
+const newUser = { id: 'user-1', email: 'test@example.com', providerCardholderId: null };
 // Helper: a user that already has a cardholder from a previous intent
 const returningUser = {
   id: 'user-2',
   email: 'returning@example.com',
-  stripeCardholderId: 'ich_existing',
+  providerCardholderId: 'ich_existing',
 };
 
 function setupHappyPathMocks(intentId: string, user = newUser) {
   (mockPrisma.purchaseIntent.findUnique as jest.Mock).mockResolvedValue({
     id: intentId,
     user,
-    currency: 'gbp',
+    currency: 'eur',
     query: 'test headphones',
     subject: null,
   });
@@ -60,12 +60,12 @@ function setupHappyPathMocks(intentId: string, user = newUser) {
   });
   (mockPrisma.user.update as jest.Mock).mockResolvedValue({
     ...user,
-    stripeCardholderId: 'ich_new',
+    providerCardholderId: 'ich_new',
   });
   (mockPrisma.virtualCard.create as jest.Mock).mockResolvedValue({
     id: 'vc-1',
     intentId,
-    stripeCardId: 'ic_123',
+    providerCardId: 'ic_123',
     last4: '4242',
   });
 }
@@ -76,12 +76,12 @@ describe('issueVirtualCard', () => {
   it('creates cardholder and card with correct spending controls', async () => {
     setupHappyPathMocks('intent-1');
 
-    const result = await issueVirtualCard('intent-1', 10000, 'gbp');
+    const result = await issueVirtualCard('intent-1', 10000, 'eur');
 
     expect(mockStripe.issuing.cards.create).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'virtual',
-        currency: 'gbp',
+        currency: 'eur',
         spending_controls: expect.objectContaining({
           spending_limits: [{ amount: 10000, interval: 'per_authorization' }],
         }),
@@ -94,7 +94,7 @@ describe('issueVirtualCard', () => {
   it('uses intentId as idempotency key', async () => {
     setupHappyPathMocks('intent-99');
 
-    await issueVirtualCard('intent-99', 5000, 'gbp');
+    await issueVirtualCard('intent-99', 5000, 'eur');
 
     expect(mockStripe.issuing.cards.create).toHaveBeenCalledWith(
       expect.anything(),
@@ -106,7 +106,7 @@ describe('issueVirtualCard', () => {
     (mockPrisma.purchaseIntent.findUnique as jest.Mock).mockResolvedValue({
       id: 'intent-1',
       user: newUser,
-      currency: 'gbp',
+      currency: 'eur',
       query: 'test',
       subject: null,
     });
@@ -120,11 +120,11 @@ describe('issueVirtualCard', () => {
     (mockPrisma.user.update as jest.Mock).mockResolvedValue({});
     (mockPrisma.virtualCard.create as jest.Mock).mockResolvedValue({
       id: 'vc-1',
-      stripeCardId: 'ic_123',
+      providerCardId: 'ic_123',
       last4: '1234',
     });
 
-    await issueVirtualCard('intent-1', 10000, 'gbp');
+    await issueVirtualCard('intent-1', 10000, 'eur');
 
     const createCall = (mockPrisma.virtualCard.create as jest.Mock).mock.calls[0][0];
     expect(createCall.data).not.toHaveProperty('number');
@@ -134,7 +134,7 @@ describe('issueVirtualCard', () => {
   it('throws IntentNotFoundError for missing intent', async () => {
     (mockPrisma.purchaseIntent.findUnique as jest.Mock).mockResolvedValue(null);
 
-    await expect(issueVirtualCard('missing-intent', 10000, 'gbp')).rejects.toThrow(
+    await expect(issueVirtualCard('missing-intent', 10000, 'eur')).rejects.toThrow(
       IntentNotFoundError,
     );
   });
@@ -142,7 +142,7 @@ describe('issueVirtualCard', () => {
   it('passes MCC allowlist to spending controls', async () => {
     setupHappyPathMocks('intent-1');
 
-    await issueVirtualCard('intent-1', 10000, 'gbp', { mccAllowlist: ['general_merchandise'] });
+    await issueVirtualCard('intent-1', 10000, 'eur', { mccAllowlist: ['general_merchandise'] });
 
     expect(mockStripe.issuing.cards.create).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -159,7 +159,7 @@ describe('issueVirtualCard', () => {
   it('sets metadata.intentId on the Stripe card for webhook correlation', async () => {
     setupHappyPathMocks('intent-webhook-test');
 
-    await issueVirtualCard('intent-webhook-test', 5000, 'gbp');
+    await issueVirtualCard('intent-webhook-test', 5000, 'eur');
 
     expect(mockStripe.issuing.cards.create).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -171,10 +171,10 @@ describe('issueVirtualCard', () => {
 
   // --- #7: cardholder upsert ---
 
-  it('creates a new Stripe cardholder when user has no stripeCardholderId', async () => {
+  it('creates a new Stripe cardholder when user has no providerCardholderId', async () => {
     setupHappyPathMocks('intent-new-user', newUser);
 
-    await issueVirtualCard('intent-new-user', 5000, 'gbp');
+    await issueVirtualCard('intent-new-user', 5000, 'eur');
 
     expect(mockStripe.issuing.cardholders.create).toHaveBeenCalledTimes(1);
     expect(mockStripe.issuing.cardholders.create).toHaveBeenCalledWith(
@@ -182,14 +182,14 @@ describe('issueVirtualCard', () => {
     );
   });
 
-  it('persists the new stripeCardholderId back to the User record', async () => {
+  it('persists the new providerCardholderId back to the User record', async () => {
     setupHappyPathMocks('intent-persist-ch', newUser);
 
-    await issueVirtualCard('intent-persist-ch', 5000, 'gbp');
+    await issueVirtualCard('intent-persist-ch', 5000, 'eur');
 
     expect(mockPrisma.user.update).toHaveBeenCalledWith({
       where: { id: newUser.id },
-      data: { stripeCardholderId: 'ich_new' },
+      data: { providerCardholderId: 'ich_new' },
     });
   });
 
@@ -197,7 +197,7 @@ describe('issueVirtualCard', () => {
     (mockPrisma.purchaseIntent.findUnique as jest.Mock).mockResolvedValue({
       id: 'intent-returning',
       user: returningUser,
-      currency: 'gbp',
+      currency: 'eur',
       query: 'test',
       subject: null,
     });
@@ -205,11 +205,11 @@ describe('issueVirtualCard', () => {
     (mockPrisma.virtualCard.create as jest.Mock).mockResolvedValue({
       id: 'vc-2',
       intentId: 'intent-returning',
-      stripeCardId: 'ic_456',
+      providerCardId: 'ic_456',
       last4: '9999',
     });
 
-    await issueVirtualCard('intent-returning', 8000, 'gbp');
+    await issueVirtualCard('intent-returning', 8000, 'eur');
 
     expect(mockStripe.issuing.cardholders.create).not.toHaveBeenCalled();
     expect(mockPrisma.user.update).not.toHaveBeenCalled();
@@ -226,7 +226,7 @@ describe('revealCard', () => {
   it('throws CardAlreadyRevealedError on second call', async () => {
     const mockCard = {
       intentId: 'intent-1',
-      stripeCardId: 'ic_123',
+      providerCardId: 'ic_123',
       last4: '4242',
       revealedAt: new Date(),
     };
@@ -238,7 +238,7 @@ describe('revealCard', () => {
   it('sets revealedAt on first call', async () => {
     const mockCard = {
       intentId: 'intent-1',
-      stripeCardId: 'ic_123',
+      providerCardId: 'ic_123',
       last4: '4242',
       revealedAt: null,
     };
@@ -275,7 +275,7 @@ describe('revealCard', () => {
   it('expands number and cvc when retrieving from Stripe', async () => {
     const mockCard = {
       intentId: 'intent-1',
-      stripeCardId: 'ic_456',
+      providerCardId: 'ic_456',
       last4: '9999',
       revealedAt: null,
     };
@@ -302,7 +302,7 @@ describe('freezeCard', () => {
   beforeEach(() => jest.clearAllMocks());
 
   it('calls Stripe with inactive status and updates DB', async () => {
-    const mockCard = { intentId: 'intent-1', stripeCardId: 'ic_123', last4: '4242' };
+    const mockCard = { intentId: 'intent-1', providerCardId: 'ic_123', last4: '4242' };
     (mockPrisma.virtualCard.findUnique as jest.Mock).mockResolvedValue(mockCard);
     mockStripe.issuing.cards.update.mockResolvedValue({});
     (mockPrisma.virtualCard.update as jest.Mock).mockResolvedValue({});
@@ -327,7 +327,7 @@ describe('cancelCard', () => {
   beforeEach(() => jest.clearAllMocks());
 
   it('calls Stripe with canceled status and updates DB', async () => {
-    const mockCard = { intentId: 'intent-1', stripeCardId: 'ic_123', last4: '4242' };
+    const mockCard = { intentId: 'intent-1', providerCardId: 'ic_123', last4: '4242' };
     (mockPrisma.virtualCard.findUnique as jest.Mock).mockResolvedValue(mockCard);
     mockStripe.issuing.cards.update.mockResolvedValue({});
     (mockPrisma.virtualCard.update as jest.Mock).mockResolvedValue({});

--- a/tests/unit/payments/checkoutSimulator.test.ts
+++ b/tests/unit/payments/checkoutSimulator.test.ts
@@ -40,7 +40,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockFindUniqueCard.mockResolvedValue({
     intentId: validParams.intentId,
-    stripeCardId: CARD_ID,
+    providerCardId: CARD_ID,
     last4: '4242',
   });
 });
@@ -58,7 +58,7 @@ describe('runSimulatedCheckout — success path', () => {
     expect(result.currency).toBe('eur');
   });
 
-  it('looks up stripeCardId from DB and passes it to the authorization', async () => {
+  it('looks up providerCardId from DB and passes it to the authorization', async () => {
     mockAuthCreate.mockResolvedValue({ id: 'iauth_lookup', approved: true, request_history: [] });
     mockAuthCapture.mockResolvedValue({ id: 'iauth_lookup', status: 'closed' });
 

--- a/tests/unit/payments/mockProvider.test.ts
+++ b/tests/unit/payments/mockProvider.test.ts
@@ -1,4 +1,5 @@
 import { MockPaymentProvider } from '@/payments/providers/mock/mockProvider';
+import { PaymentProvider } from '@/contracts';
 
 describe('MockPaymentProvider', () => {
   let provider: MockPaymentProvider;
@@ -7,14 +8,23 @@ describe('MockPaymentProvider', () => {
     provider = new MockPaymentProvider();
   });
 
+  describe('metadata', () => {
+    it('exposes provider metadata with Stripe-compatible defaults', () => {
+      expect(provider.metadata).toEqual({
+        id: PaymentProvider.STRIPE,
+        currency: 'eur',
+      });
+    });
+  });
+
   describe('issueCard', () => {
     it('returns a VirtualCardData with mock values', async () => {
-      const result = await provider.issueCard('intent-1', 5000, 'eur');
+      const result = await provider.issueCard('intent-1', 5000);
 
       expect(result).toMatchObject({
         id: 'mock-card-intent-1',
         intentId: 'intent-1',
-        stripeCardId: 'mock_stripe_intent-1',
+        providerCardId: 'mock_provider_intent-1',
         last4: '4242',
         revealedAt: null,
         frozenAt: null,
@@ -24,12 +34,12 @@ describe('MockPaymentProvider', () => {
     });
 
     it('passes options through to call recording', async () => {
-      await provider.issueCard('intent-2', 10000, 'gbp', { mccAllowlist: ['5411'] });
+      await provider.issueCard('intent-2', 10000, { mccAllowlist: ['5411'] });
 
       const calls = provider.getCalls();
       expect(calls).toHaveLength(1);
       expect(calls[0].method).toBe('issueCard');
-      expect(calls[0].args).toEqual(['intent-2', 10000, 'gbp', { mccAllowlist: ['5411'] }]);
+      expect(calls[0].args).toEqual(['intent-2', 10000, { mccAllowlist: ['5411'] }]);
     });
   });
 
@@ -106,7 +116,7 @@ describe('MockPaymentProvider', () => {
 
   describe('call recording', () => {
     it('records calls across multiple methods in order', async () => {
-      await provider.issueCard('i1', 1000, 'eur');
+      await provider.issueCard('i1', 1000);
       await provider.revealCard('i1');
       await provider.cancelCard('i1');
 
@@ -117,7 +127,7 @@ describe('MockPaymentProvider', () => {
 
     it('includes timestamps on each call', async () => {
       const before = Date.now();
-      await provider.issueCard('i1', 1000, 'eur');
+      await provider.issueCard('i1', 1000);
       const after = Date.now();
 
       const calls = provider.getCalls();
@@ -126,7 +136,7 @@ describe('MockPaymentProvider', () => {
     });
 
     it('getCalls() returns a copy — mutations do not affect internal state', async () => {
-      await provider.issueCard('i1', 1000, 'eur');
+      await provider.issueCard('i1', 1000);
 
       const calls = provider.getCalls();
       calls.length = 0;
@@ -136,7 +146,7 @@ describe('MockPaymentProvider', () => {
 
     it('two instances have independent call logs', async () => {
       const other = new MockPaymentProvider();
-      await provider.issueCard('i1', 1000, 'eur');
+      await provider.issueCard('i1', 1000);
       await other.freezeCard('i2');
 
       expect(provider.getCalls()).toHaveLength(1);
@@ -147,31 +157,25 @@ describe('MockPaymentProvider', () => {
   });
 
   describe('getIssuingBalance', () => {
-    it('returns a high default balance', async () => {
-      const result = await provider.getIssuingBalance('gbp');
+    it('returns a high default balance in the metadata currency', async () => {
+      const result = await provider.getIssuingBalance();
 
-      expect(result).toEqual({ available: 999_999_99, currency: 'gbp' });
-    });
-
-    it('normalises currency to lowercase', async () => {
-      const result = await provider.getIssuingBalance('EUR');
-
-      expect(result.currency).toBe('eur');
+      expect(result).toEqual({ available: 999_999_99, currency: 'eur' });
     });
 
     it('records the call', async () => {
-      await provider.getIssuingBalance('usd');
+      await provider.getIssuingBalance();
 
       const calls = provider.getCalls();
       expect(calls).toHaveLength(1);
       expect(calls[0].method).toBe('getIssuingBalance');
-      expect(calls[0].args).toEqual(['usd']);
+      expect(calls[0].args).toEqual([]);
     });
 
     it('returns overridden balance after setIssuingBalance', async () => {
       provider.setIssuingBalance(500);
 
-      const result = await provider.getIssuingBalance('gbp');
+      const result = await provider.getIssuingBalance();
 
       expect(result.available).toBe(500);
     });
@@ -179,7 +183,7 @@ describe('MockPaymentProvider', () => {
     it('setIssuingBalance(0) makes balance zero', async () => {
       provider.setIssuingBalance(0);
 
-      const result = await provider.getIssuingBalance('gbp');
+      const result = await provider.getIssuingBalance();
 
       expect(result.available).toBe(0);
     });
@@ -187,7 +191,7 @@ describe('MockPaymentProvider', () => {
 
   describe('clearCalls', () => {
     it('removes all recorded calls', async () => {
-      await provider.issueCard('i1', 1000, 'eur');
+      await provider.issueCard('i1', 1000);
       await provider.revealCard('i1');
       expect(provider.getCalls()).toHaveLength(2);
 

--- a/tests/unit/payments/providerFactory.test.ts
+++ b/tests/unit/payments/providerFactory.test.ts
@@ -177,5 +177,12 @@ describe('providerFactory — getProviderForUser / getProviderForIntent', () => 
 
       await expect(getProviderForIntent('missing-intent')).rejects.toThrow(IntentNotFoundError);
     });
+
+    it('rethrows non-P2025 errors unchanged', async () => {
+      const dbErr = new Error('connection refused');
+      (prisma.purchaseIntent.findUniqueOrThrow as jest.Mock).mockRejectedValue(dbErr);
+
+      await expect(getProviderForIntent('intent-1')).rejects.toBe(dbErr);
+    });
   });
 });

--- a/tests/unit/payments/providerFactory.test.ts
+++ b/tests/unit/payments/providerFactory.test.ts
@@ -1,4 +1,14 @@
-describe('providerFactory', () => {
+import { PaymentProvider, IntentNotFoundError, UserNotFoundError } from '@/contracts';
+import { Prisma } from '@prisma/client';
+
+jest.mock('@/db/client', () => ({
+  prisma: {
+    user: { findUniqueOrThrow: jest.fn() },
+    purchaseIntent: { findUniqueOrThrow: jest.fn() },
+  },
+}));
+
+describe('providerFactory — getPaymentProvider (env-driven)', () => {
   let getPaymentProvider: typeof import('@/payments/providerFactory').getPaymentProvider;
   let resetPaymentProvider: typeof import('@/payments/providerFactory').resetPaymentProvider;
 
@@ -17,7 +27,7 @@ describe('providerFactory', () => {
     const original = process.env.NODE_ENV;
     process.env.NODE_ENV = 'test';
     try {
-      const provider = getPaymentProvider();
+      const provider = getPaymentProvider(PaymentProvider.STRIPE);
       expect(provider.constructor.name).toBe('MockPaymentProvider');
     } finally {
       process.env.NODE_ENV = original;
@@ -30,7 +40,7 @@ describe('providerFactory', () => {
     process.env.NODE_ENV = 'production';
     process.env.PAYMENT_PROVIDER = 'mock';
     try {
-      const provider = getPaymentProvider();
+      const provider = getPaymentProvider(PaymentProvider.STRIPE);
       expect(provider.constructor.name).toBe('MockPaymentProvider');
     } finally {
       process.env.NODE_ENV = origEnv;
@@ -42,48 +52,37 @@ describe('providerFactory', () => {
     }
   });
 
-  it('returns the same singleton on repeated calls', () => {
-    const p1 = getPaymentProvider();
-    const p2 = getPaymentProvider();
+  it('caches instances per provider type', () => {
+    const p1 = getPaymentProvider(PaymentProvider.STRIPE);
+    const p2 = getPaymentProvider(PaymentProvider.STRIPE);
     expect(p1).toBe(p2);
   });
 
   it('returns a new instance after resetPaymentProvider', () => {
-    const p1 = getPaymentProvider();
+    const p1 = getPaymentProvider(PaymentProvider.STRIPE);
     resetPaymentProvider();
-    const p2 = getPaymentProvider();
+    const p2 = getPaymentProvider(PaymentProvider.STRIPE);
     expect(p1).not.toBe(p2);
   });
 
-  it('returns MockPaymentProvider when NODE_ENV=test even if PAYMENT_PROVIDER=stripe', () => {
+  it('returns MockPaymentProvider when NODE_ENV=test regardless of requested type', () => {
     const origEnv = process.env.NODE_ENV;
-    const origProvider = process.env.PAYMENT_PROVIDER;
     process.env.NODE_ENV = 'test';
-    process.env.PAYMENT_PROVIDER = 'stripe';
     try {
-      const provider = getPaymentProvider();
+      const provider = getPaymentProvider(PaymentProvider.STRIPE);
       expect(provider.constructor.name).toBe('MockPaymentProvider');
     } finally {
       process.env.NODE_ENV = origEnv;
-      if (origProvider === undefined) {
-        delete process.env.PAYMENT_PROVIDER;
-      } else {
-        process.env.PAYMENT_PROVIDER = origProvider;
-      }
     }
   });
 
-  it('defaults PAYMENT_PROVIDER to stripe when not set', () => {
+  it('loads StripePaymentProvider when type=STRIPE and no mock override', () => {
     const origEnv = process.env.NODE_ENV;
     const origProvider = process.env.PAYMENT_PROVIDER;
     process.env.NODE_ENV = 'production';
     delete process.env.PAYMENT_PROVIDER;
     try {
-      // In production with no PAYMENT_PROVIDER set, it should try to load StripePaymentProvider.
-      // We don't have Stripe keys, so this will fail during Stripe client init, but we can
-      // verify the factory attempts to load the stripe provider by catching the error.
-      const provider = getPaymentProvider();
-      // If we get here, the StripePaymentProvider was loaded (unlikely in test without keys)
+      const provider = getPaymentProvider(PaymentProvider.STRIPE);
       expect(provider.constructor.name).toBe('StripePaymentProvider');
     } catch {
       // Expected: Stripe key not set in test env — confirms it tried to load stripe
@@ -98,12 +97,85 @@ describe('providerFactory', () => {
   });
 
   it('provider implements all IPaymentProvider methods', () => {
-    const provider = getPaymentProvider();
+    const provider = getPaymentProvider(PaymentProvider.STRIPE);
     expect(typeof provider.issueCard).toBe('function');
     expect(typeof provider.revealCard).toBe('function');
     expect(typeof provider.freezeCard).toBe('function');
     expect(typeof provider.cancelCard).toBe('function');
     expect(typeof provider.handleWebhookEvent).toBe('function');
     expect(typeof provider.getIssuingBalance).toBe('function');
+    expect(provider.metadata).toBeDefined();
+    expect(provider.metadata.id).toBe(PaymentProvider.STRIPE);
+  });
+});
+
+describe('providerFactory — getProviderForUser / getProviderForIntent', () => {
+  // No resetModules here — need a stable prisma mock across tests
+  const { getProviderForUser, getProviderForIntent } = require('@/payments/providerFactory');
+  const { prisma } = require('@/db/client');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getProviderForUser', () => {
+    it('resolves the user and returns the provider matching user.paymentProvider', async () => {
+      (prisma.user.findUniqueOrThrow as jest.Mock).mockResolvedValue({
+        paymentProvider: PaymentProvider.STRIPE,
+      });
+
+      const provider = await getProviderForUser('user-1');
+
+      expect(prisma.user.findUniqueOrThrow).toHaveBeenCalledWith({
+        where: { id: 'user-1' },
+        select: { paymentProvider: true },
+      });
+      expect(provider.metadata.id).toBe(PaymentProvider.STRIPE);
+    });
+
+    it('translates Prisma P2025 into UserNotFoundError', async () => {
+      (prisma.user.findUniqueOrThrow as jest.Mock).mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('no record', {
+          code: 'P2025',
+          clientVersion: 'test',
+        }),
+      );
+
+      await expect(getProviderForUser('missing-user')).rejects.toThrow(UserNotFoundError);
+    });
+
+    it('rethrows non-P2025 errors unchanged', async () => {
+      const dbErr = new Error('connection refused');
+      (prisma.user.findUniqueOrThrow as jest.Mock).mockRejectedValue(dbErr);
+
+      await expect(getProviderForUser('user-1')).rejects.toBe(dbErr);
+    });
+  });
+
+  describe('getProviderForIntent', () => {
+    it('resolves the intent and returns the provider matching the owning user', async () => {
+      (prisma.purchaseIntent.findUniqueOrThrow as jest.Mock).mockResolvedValue({
+        user: { paymentProvider: PaymentProvider.STRIPE },
+      });
+
+      const provider = await getProviderForIntent('intent-1');
+
+      expect(prisma.purchaseIntent.findUniqueOrThrow).toHaveBeenCalledWith({
+        where: { id: 'intent-1' },
+        select: { user: { select: { paymentProvider: true } } },
+      });
+      expect(provider.metadata.id).toBe(PaymentProvider.STRIPE);
+    });
+
+    it('translates Prisma P2025 into IntentNotFoundError', async () => {
+      (prisma.purchaseIntent.findUniqueOrThrow as jest.Mock).mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('no record', {
+          code: 'P2025',
+          clientVersion: 'test',
+        }),
+      );
+
+      await expect(getProviderForIntent('missing-intent')).rejects.toThrow(IntentNotFoundError);
+    });
   });
 });

--- a/tests/unit/payments/reconciliationService.test.ts
+++ b/tests/unit/payments/reconciliationService.test.ts
@@ -1,15 +1,15 @@
-// Mock stripe before imports
+const mockAutoPagingToArray = jest.fn();
+const mockTransactionsList = jest.fn(() => ({ autoPagingToArray: mockAutoPagingToArray }));
 const mockStripe = {
   issuing: {
     cards: { retrieve: jest.fn() },
-    transactions: { list: jest.fn() },
+    transactions: { list: mockTransactionsList },
   },
 };
 jest.mock('@/payments/providers/stripe/stripeClient', () => ({
   getStripeClient: () => mockStripe,
 }));
 
-// Mock prisma before imports
 const mockPot = jest.fn();
 const mockLedgerEntries = jest.fn();
 const mockVirtualCard = jest.fn();
@@ -21,87 +21,218 @@ jest.mock('@/db/client', () => ({
   },
 }));
 
+const mockChildLogger = {
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+};
+jest.mock('@/config/logger', () => ({
+  logger: { child: jest.fn(() => mockChildLogger) },
+}));
+
 import { reconcileIntent } from '@/payments/providers/stripe/reconciliationService';
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockChildLogger.error.mockClear();
 });
 
-describe('reconcileIntent', () => {
-  it('returns inSync:true when settledAmount matches stripe captured and card is canceled', async () => {
+describe('reconcileIntent — capture amount sign handling (issue #88)', () => {
+  it('treats Stripe-style negative capture amounts as positive captured totals', async () => {
     mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 3500, status: 'SETTLED' });
-    mockLedgerEntries.mockResolvedValue([
-      { type: 'RESERVE', amount: 5000 },
-      { type: 'SETTLE', amount: 3500 },
-    ]);
-    mockVirtualCard.mockResolvedValue({ intentId: 'intent-1', stripeCardId: 'ic_123' });
+    mockLedgerEntries.mockResolvedValue([{ type: 'SETTLE', amount: 3500 }]);
+    mockVirtualCard.mockResolvedValue({ intentId: 'intent-1', providerCardId: 'ic_neg' });
     mockStripe.issuing.cards.retrieve.mockResolvedValue({ status: 'canceled' });
-    mockStripe.issuing.transactions.list.mockResolvedValue({
-      data: [{ id: 'itxn_1', amount: 3500, type: 'capture' }],
-    });
+    mockAutoPagingToArray.mockResolvedValue([{ id: 'itxn_1', amount: -3500, type: 'capture' }]);
 
     const report = await reconcileIntent('intent-1');
 
+    expect(report.stripe?.totalCaptured).toBe(3500);
     expect(report.inSync).toBe(true);
     expect(report.discrepancies).toHaveLength(0);
-    expect(report.stripe?.totalCaptured).toBe(3500);
   });
 
-  it('returns inSync:false with discrepancy when settledAmount differs from stripe captured', async () => {
+  it('flags a real settlement mismatch', async () => {
     mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 3500, status: 'SETTLED' });
     mockLedgerEntries.mockResolvedValue([]);
-    mockVirtualCard.mockResolvedValue({ intentId: 'intent-2', stripeCardId: 'ic_456' });
+    mockVirtualCard.mockResolvedValue({ intentId: 'intent-2', providerCardId: 'ic_mis' });
     mockStripe.issuing.cards.retrieve.mockResolvedValue({ status: 'canceled' });
-    mockStripe.issuing.transactions.list.mockResolvedValue({
-      data: [{ id: 'itxn_2', amount: 4000, type: 'capture' }],
-    });
+    mockAutoPagingToArray.mockResolvedValue([{ id: 'itxn_2', amount: -4000, type: 'capture' }]);
 
     const report = await reconcileIntent('intent-2');
 
     expect(report.inSync).toBe(false);
     expect(report.discrepancies).toContain('settledAmount 3500 != stripe captured 4000');
   });
+});
 
-  it('returns inSync:false with discrepancy when pot is SETTLED but card is still active', async () => {
-    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 3500, status: 'SETTLED' });
-    mockLedgerEntries.mockResolvedValue([]);
-    mockVirtualCard.mockResolvedValue({ intentId: 'intent-3', stripeCardId: 'ic_789' });
-    mockStripe.issuing.cards.retrieve.mockResolvedValue({ status: 'active' });
-    mockStripe.issuing.transactions.list.mockResolvedValue({
-      data: [{ id: 'itxn_3', amount: 3500, type: 'capture' }],
-    });
+describe('reconcileIntent — refunds (issue #88)', () => {
+  it('subtracts refund transactions from the net captured total', async () => {
+    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 3000, status: 'SETTLED' });
+    mockLedgerEntries.mockResolvedValue([{ type: 'SETTLE', amount: 3000 }]);
+    mockVirtualCard.mockResolvedValue({ intentId: 'intent-3', providerCardId: 'ic_refund' });
+    mockStripe.issuing.cards.retrieve.mockResolvedValue({ status: 'canceled' });
+    mockAutoPagingToArray.mockResolvedValue([
+      { id: 'itxn_cap', amount: -4000, type: 'capture' },
+      { id: 'itxn_ref', amount: 1000, type: 'refund' },
+    ]);
 
     const report = await reconcileIntent('intent-3');
+
+    expect(report.stripe?.totalCaptured).toBe(3000);
+    expect(report.inSync).toBe(true);
+  });
+});
+
+describe('reconcileIntent — Stripe API error handling (issue #88)', () => {
+  it('returns a discrepancy report instead of throwing when cards.retrieve fails', async () => {
+    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 3500, status: 'SETTLED' });
+    mockLedgerEntries.mockResolvedValue([]);
+    mockVirtualCard.mockResolvedValue({ intentId: 'intent-err', providerCardId: 'ic_404' });
+    mockStripe.issuing.cards.retrieve.mockRejectedValue(new Error('No such card: ic_404'));
+
+    const report = await reconcileIntent('intent-err');
+
+    expect(report.inSync).toBe(false);
+    expect(report.stripe).toBeNull();
+    expect(report.discrepancies[0]).toContain('stripe API error');
+    expect(mockChildLogger.error).toHaveBeenCalled();
+  });
+
+  it('returns a discrepancy report when transactions.list paging fails', async () => {
+    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 3500, status: 'SETTLED' });
+    mockLedgerEntries.mockResolvedValue([]);
+    mockVirtualCard.mockResolvedValue({ intentId: 'intent-429', providerCardId: 'ic_429' });
+    mockStripe.issuing.cards.retrieve.mockResolvedValue({ status: 'canceled' });
+    mockAutoPagingToArray.mockRejectedValue(new Error('Too many requests'));
+
+    const report = await reconcileIntent('intent-429');
+
+    expect(report.inSync).toBe(false);
+    expect(report.stripe).toBeNull();
+    expect(report.discrepancies[0]).toContain('Too many requests');
+  });
+});
+
+describe('reconcileIntent — pagination (issue #88)', () => {
+  it('uses autoPagingToArray with a safety cap', async () => {
+    const txs = Array.from({ length: 250 }, (_, i) => ({
+      id: `itxn_${i}`,
+      amount: -10,
+      type: 'capture',
+    }));
+    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 2500, status: 'SETTLED' });
+    mockLedgerEntries.mockResolvedValue([]);
+    mockVirtualCard.mockResolvedValue({ intentId: 'intent-page', providerCardId: 'ic_page' });
+    mockStripe.issuing.cards.retrieve.mockResolvedValue({ status: 'canceled' });
+    mockAutoPagingToArray.mockResolvedValue(txs);
+
+    const report = await reconcileIntent('intent-page');
+
+    expect(mockAutoPagingToArray).toHaveBeenCalledWith({ limit: 1000 });
+    expect(report.stripe?.totalCaptured).toBe(2500);
+    expect(report.inSync).toBe(true);
+  });
+
+  it('flags a discrepancy when the safety cap is hit', async () => {
+    const txs = Array.from({ length: 1000 }, (_, i) => ({
+      id: `itxn_${i}`,
+      amount: -1,
+      type: 'capture',
+    }));
+    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 1000, status: 'SETTLED' });
+    mockLedgerEntries.mockResolvedValue([]);
+    mockVirtualCard.mockResolvedValue({ intentId: 'intent-cap', providerCardId: 'ic_cap' });
+    mockStripe.issuing.cards.retrieve.mockResolvedValue({ status: 'canceled' });
+    mockAutoPagingToArray.mockResolvedValue(txs);
+
+    const report = await reconcileIntent('intent-cap');
+
+    expect(report.inSync).toBe(false);
+    expect(report.discrepancies.some((d) => d.includes('truncated at 1000'))).toBe(true);
+  });
+});
+
+describe('reconcileIntent — missing virtualCard (issue #88)', () => {
+  it('returns inSync:true when neither pot nor card exists', async () => {
+    mockPot.mockResolvedValue(null);
+    mockLedgerEntries.mockResolvedValue([]);
+    mockVirtualCard.mockResolvedValue(null);
+
+    const report = await reconcileIntent('intent-empty');
+
+    expect(report.stripe).toBeNull();
+    expect(report.inSync).toBe(true);
+    expect(mockStripe.issuing.cards.retrieve).not.toHaveBeenCalled();
+  });
+
+  it('returns inSync:true when pot is ACTIVE with no settled funds (in-flight)', async () => {
+    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 0, status: 'ACTIVE' });
+    mockLedgerEntries.mockResolvedValue([{ type: 'RESERVE', amount: 5000 }]);
+    mockVirtualCard.mockResolvedValue(null);
+
+    const report = await reconcileIntent('intent-inflight');
+
+    expect(report.inSync).toBe(true);
+    expect(report.discrepancies).toHaveLength(0);
+  });
+
+  it('returns inSync:false when pot is SETTLED but no virtualCard record exists', async () => {
+    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 3500, status: 'SETTLED' });
+    mockLedgerEntries.mockResolvedValue([{ type: 'SETTLE', amount: 3500 }]);
+    mockVirtualCard.mockResolvedValue(null);
+
+    const report = await reconcileIntent('intent-orphaned-pot');
+
+    expect(report.inSync).toBe(false);
+    expect(
+      report.discrepancies.some((d) => d.includes('virtualCard missing') && d.includes('SETTLED')),
+    ).toBe(true);
+  });
+});
+
+describe('reconcileIntent — card status', () => {
+  it('reports a discrepancy when pot is SETTLED but Stripe card is still active', async () => {
+    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 3500, status: 'SETTLED' });
+    mockLedgerEntries.mockResolvedValue([]);
+    mockVirtualCard.mockResolvedValue({ intentId: 'intent-status', providerCardId: 'ic_active' });
+    mockStripe.issuing.cards.retrieve.mockResolvedValue({ status: 'active' });
+    mockAutoPagingToArray.mockResolvedValue([{ id: 'itxn_x', amount: -3500, type: 'capture' }]);
+
+    const report = await reconcileIntent('intent-status');
 
     expect(report.inSync).toBe(false);
     expect(
       report.discrepancies.some((d) => d.includes('expects card canceled but got active')),
     ).toBe(true);
   });
+});
 
-  it('returns stripe:null and inSync:true when no VirtualCard exists', async () => {
-    mockPot.mockResolvedValue({ reservedAmount: 5000, settledAmount: 0, status: 'ACTIVE' });
-    mockLedgerEntries.mockResolvedValue([]);
-    mockVirtualCard.mockResolvedValue(null);
-
-    const report = await reconcileIntent('intent-4');
-
-    expect(report.stripe).toBeNull();
-    expect(report.inSync).toBe(true);
-    expect(report.discrepancies).toHaveLength(0);
-    expect(mockStripe.issuing.cards.retrieve).not.toHaveBeenCalled();
-  });
-
-  it('returns potStatus:null and inSync:true when no Pot exists', async () => {
+describe('reconcileIntent — internal report fields', () => {
+  it('reports zero balances and null potStatus when no pot exists', async () => {
     mockPot.mockResolvedValue(null);
     mockLedgerEntries.mockResolvedValue([]);
     mockVirtualCard.mockResolvedValue(null);
 
-    const report = await reconcileIntent('intent-5');
+    const report = await reconcileIntent('intent-no-pot');
 
     expect(report.internal.potStatus).toBeNull();
     expect(report.internal.reserved).toBe(0);
     expect(report.internal.settled).toBe(0);
     expect(report.inSync).toBe(true);
+  });
+
+  it('serialises ledger entries into "TYPE:amount" strings', async () => {
+    mockPot.mockResolvedValue(null);
+    mockLedgerEntries.mockResolvedValue([
+      { type: 'RESERVE', amount: 5000 },
+      { type: 'SETTLE', amount: 3500 },
+    ]);
+    mockVirtualCard.mockResolvedValue(null);
+
+    const report = await reconcileIntent('intent-ledger');
+
+    expect(report.internal.ledgerEntries).toEqual(['RESERVE:5000', 'SETTLE:3500']);
   });
 });

--- a/tests/unit/payments/stripeProvider.test.ts
+++ b/tests/unit/payments/stripeProvider.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Pins that StripePaymentProvider forwards metadata.currency (not a caller-supplied
+ * currency) to the underlying cardService. Guards against the divergence bug where
+ * the provider could silently issue cards in a currency that doesn't match the
+ * ledger's intent.currency.
+ */
+const mockIssueVirtualCard = jest.fn();
+const mockFetchIssuingBalance = jest.fn();
+jest.mock('@/payments/providers/stripe/cardService', () => ({
+  issueVirtualCard: mockIssueVirtualCard,
+  revealCard: jest.fn(),
+  freezeCard: jest.fn(),
+  cancelCard: jest.fn(),
+}));
+jest.mock('@/payments/providers/stripe/balanceService', () => ({
+  getIssuingBalance: mockFetchIssuingBalance,
+}));
+jest.mock('@/payments/providers/stripe/webhookHandler', () => ({
+  handleStripeEvent: jest.fn(),
+}));
+
+import { StripePaymentProvider } from '@/payments/providers/stripe';
+import { PaymentProvider } from '@/contracts';
+
+describe('StripePaymentProvider', () => {
+  let provider: StripePaymentProvider;
+
+  beforeEach(() => {
+    provider = new StripePaymentProvider();
+    jest.clearAllMocks();
+  });
+
+  describe('metadata', () => {
+    it('exposes Stripe provider metadata with EUR currency', () => {
+      expect(provider.metadata).toEqual({
+        id: PaymentProvider.STRIPE,
+        currency: 'eur',
+      });
+    });
+  });
+
+  describe('issueCard', () => {
+    it('forwards metadata.currency to cardService (not a caller-supplied value)', async () => {
+      mockIssueVirtualCard.mockResolvedValue({
+        id: 'vc-1',
+        intentId: 'intent-1',
+        providerCardId: 'ic_test',
+        last4: '4242',
+      });
+
+      await provider.issueCard('intent-1', 5000, { mccAllowlist: ['5411'] });
+
+      expect(mockIssueVirtualCard).toHaveBeenCalledWith('intent-1', 5000, 'eur', {
+        mccAllowlist: ['5411'],
+      });
+    });
+  });
+
+  describe('getIssuingBalance', () => {
+    it('forwards metadata.currency to balanceService', async () => {
+      mockFetchIssuingBalance.mockResolvedValue({ available: 1000, currency: 'eur' });
+
+      await provider.getIssuingBalance();
+
+      expect(mockFetchIssuingBalance).toHaveBeenCalledWith('eur');
+    });
+  });
+});

--- a/tests/unit/queue/producers.test.ts
+++ b/tests/unit/queue/producers.test.ts
@@ -41,7 +41,7 @@ describe('enqueueCheckout', () => {
       merchantUrl: 'https://amazon.co.uk',
       price: 9999,
       currency: 'gbp',
-      stripeCardId: 'ic_123',
+      providerCardId: 'ic_123',
       last4: '4242',
     };
 

--- a/tests/unit/telegram/callbackHandler.test.ts
+++ b/tests/unit/telegram/callbackHandler.test.ts
@@ -38,7 +38,7 @@ jest.mock('@/ledger/potService', () => ({
   returnIntent: mockReturnIntent,
 }));
 
-const mockIssueCard = jest.fn().mockResolvedValue({ stripeCardId: 'ic_test', last4: '4242' });
+const mockIssueCard = jest.fn().mockResolvedValue({ providerCardId: 'ic_test', last4: '4242' });
 const mockRevealCard = jest.fn().mockResolvedValue({
   number: '4242424242424242',
   cvc: '123',
@@ -51,7 +51,7 @@ const mockCancelCard = jest.fn().mockResolvedValue(undefined);
 const mockHandleWebhookEvent = jest.fn().mockResolvedValue(undefined);
 const mockGetIssuingBalance = jest
   .fn()
-  .mockResolvedValue({ available: 999_999_99, currency: 'gbp' });
+  .mockResolvedValue({ available: 999_999_99, currency: 'eur' });
 const mockProvider = {
   issueCard: mockIssueCard,
   revealCard: mockRevealCard,
@@ -62,6 +62,8 @@ const mockProvider = {
 };
 jest.mock('@/payments', () => ({
   getPaymentProvider: () => mockProvider,
+  getProviderForIntent: () => Promise.resolve(mockProvider),
+  getProviderForUser: () => Promise.resolve(mockProvider),
 }));
 
 const mockMarkCardIssued = jest.fn().mockResolvedValue({});
@@ -114,7 +116,7 @@ beforeEach(() => {
 
   mockAnswerCallbackQuery.mockResolvedValue(undefined);
   mockEditMessageText.mockResolvedValue(undefined);
-  mockIssueCard.mockResolvedValue({ stripeCardId: 'ic_test', last4: '4242' });
+  mockIssueCard.mockResolvedValue({ providerCardId: 'ic_test', last4: '4242' });
   mockGetSession.mockResolvedValue(null);
   mockSetSession.mockResolvedValue(undefined);
   mockClearSession.mockResolvedValue(undefined);
@@ -137,9 +139,9 @@ function seedAwaitingIntent(id: string) {
     userId: 'user-1',
     status: IntentStatus.AWAITING_APPROVAL,
     maxBudget: 10000,
-    currency: 'gbp',
+    currency: 'eur',
     metadata: { merchantName: 'Amazon UK', merchantUrl: 'https://amazon.co.uk', price: 9999 },
-    user: { id: 'user-1', mccAllowlist: [] },
+    user: { id: 'user-1', mccAllowlist: [], paymentProvider: 'STRIPE' },
   };
 }
 
@@ -248,7 +250,7 @@ describe('handleTelegramCallback — approve path', () => {
     });
     mockGetIssuingBalance.mockImplementation(() => {
       callOrder.push('balance');
-      return Promise.resolve({ available: 999_999_99, currency: 'gbp' });
+      return Promise.resolve({ available: 999_999_99, currency: 'eur' });
     });
     mockRecordDecision.mockImplementation(() => {
       callOrder.push('record');
@@ -267,7 +269,7 @@ describe('handleTelegramCallback — approve path', () => {
     const order: string[] = [];
     mockGetIssuingBalance.mockImplementation(() => {
       order.push('getIssuingBalance');
-      return Promise.resolve({ available: 999_999_99, currency: 'gbp' });
+      return Promise.resolve({ available: 999_999_99, currency: 'eur' });
     });
     mockRecordDecision.mockImplementation(() => {
       order.push('recordDecision');
@@ -279,7 +281,7 @@ describe('handleTelegramCallback — approve path', () => {
     });
     mockIssueCard.mockImplementation(() => {
       order.push('issueCard');
-      return Promise.resolve({ stripeCardId: 'ic_t', last4: '4242' });
+      return Promise.resolve({ providerCardId: 'ic_t', last4: '4242' });
     });
     mockMarkCardIssued.mockImplementation(() => {
       order.push('markCardIssued');
@@ -398,7 +400,7 @@ describe('handleTelegramCallback — idempotency guard', () => {
 describe('handleTelegramCallback — insufficient Issuing balance', () => {
   it('does not record decision, reserve, or issue card when Issuing balance is insufficient', async () => {
     seedAwaitingIntent('intent-bal1');
-    mockGetIssuingBalance.mockResolvedValueOnce({ available: 500, currency: 'gbp' });
+    mockGetIssuingBalance.mockResolvedValueOnce({ available: 500, currency: 'eur' });
 
     await handleTelegramCallback(makeUpdate('approve', 'intent-bal1', 'cb-bal1'));
 
@@ -410,7 +412,7 @@ describe('handleTelegramCallback — insufficient Issuing balance', () => {
 
   it('edits message with balance error when insufficient', async () => {
     seedAwaitingIntent('intent-bal2');
-    mockGetIssuingBalance.mockResolvedValueOnce({ available: 500, currency: 'gbp' });
+    mockGetIssuingBalance.mockResolvedValueOnce({ available: 500, currency: 'eur' });
 
     await handleTelegramCallback(makeUpdate('approve', 'intent-bal2', 'cb-bal2'));
 
@@ -424,7 +426,7 @@ describe('handleTelegramCallback — insufficient Issuing balance', () => {
 
   it('does not re-throw — handles gracefully', async () => {
     seedAwaitingIntent('intent-bal3');
-    mockGetIssuingBalance.mockResolvedValueOnce({ available: 0, currency: 'gbp' });
+    mockGetIssuingBalance.mockResolvedValueOnce({ available: 0, currency: 'eur' });
 
     await expect(
       handleTelegramCallback(makeUpdate('approve', 'intent-bal3', 'cb-bal3')),
@@ -469,7 +471,7 @@ describe('handleTelegramCallback — issueVirtualCard failure compensation', () 
     ).rejects.toThrow();
 
     // Re-run with same callbackQueryId — idempotency guard should block it
-    mockIssueCard.mockResolvedValue({ stripeCardId: 'ic_t', last4: '4242' });
+    mockIssueCard.mockResolvedValue({ providerCardId: 'ic_t', last4: '4242' });
     jest.clearAllMocks();
     // Restore the idempotency entry (upsert mock already saved it via the real dbIdempotency object)
     await handleTelegramCallback(makeUpdate('approve', 'intent-idem2', 'cb-idem2'));

--- a/tests/unit/telegram/menuHandler.test.ts
+++ b/tests/unit/telegram/menuHandler.test.ts
@@ -22,11 +22,19 @@ jest.mock('@/orchestrator/intentService', () => ({
   expireIntent: (...args: any[]) => mockExpireIntent(...args),
 }));
 
-// Mock payment provider
+// Mock payment provider — separate jest.fn() per resolver so tests can assert
+// the call site uses the right one (an intent-scoped flow must call
+// getProviderForIntent, not getPaymentProvider with a hardcoded id).
 const mockCancelCard = jest.fn();
 const mockFreezeCard = jest.fn();
+const mockProvider = { cancelCard: mockCancelCard, freezeCard: mockFreezeCard };
+const mockGetPaymentProvider = jest.fn(() => mockProvider);
+const mockGetProviderForIntent = jest.fn(() => Promise.resolve(mockProvider));
+const mockGetProviderForUser = jest.fn(() => Promise.resolve(mockProvider));
 jest.mock('@/payments', () => ({
-  getPaymentProvider: () => ({ cancelCard: mockCancelCard, freezeCard: mockFreezeCard }),
+  getPaymentProvider: (...args: any[]) => mockGetPaymentProvider(...args),
+  getProviderForIntent: (...args: any[]) => mockGetProviderForIntent(...args),
+  getProviderForUser: (...args: any[]) => mockGetProviderForUser(...args),
 }));
 
 // Mock sessionStore
@@ -517,6 +525,10 @@ describe('menu_card_cancel', () => {
     );
 
     expect(mockCancelCard).toHaveBeenCalledWith('intent-abc');
+    // The cancel flow is intent-scoped — must resolve the provider via the
+    // intent, not a hardcoded id passed to getPaymentProvider.
+    expect(mockGetProviderForIntent).toHaveBeenCalledWith('intent-abc');
+    expect(mockGetPaymentProvider).not.toHaveBeenCalled();
     const text = mockEditMessageText.mock.calls[0][2] as string;
     expect(text.toLowerCase()).toContain('cancelled');
   });


### PR DESCRIPTION
## Summary

Supersedes #129. This is a clean signed-history redo of the
payment-provider abstraction work — the prior branch had one unsigned
commit (carried over from #132's verification work) that branch
protection refused to merge, and a noisy history (Privacy.com added then
reverted, three rounds of CodeRabbit fix-ups) that made review hard to
follow. Same final tree, three commits, all SSH-signed.

## Why

The payments module was tightly coupled to Stripe naming
(`stripeCardId`, `stripeCardholderId`) and per-call `currency` params,
which would have made dropping in a second provider (Privacy.com, #106)
a much bigger surface change. This PR decouples that.

## What's in this PR

**`feat(issue-105)`**
- `VirtualCardData.stripeCardId` → `providerCardId`; `VirtualCard` also
  carries `provider` so freeze/cancel can route without an extra DB lookup
- `CheckoutIntentJob.stripeCardId` → `providerCardId`
- New `PaymentProvider` enum + `ProviderMetadata` in
  `src/contracts/payment.ts`; `IPaymentProvider` exposes `readonly metadata`
- `currency` param dropped from `issueCard` and `getIssuingBalance` —
  each provider declares its currency in `metadata`
- New `UserNotFoundError` so the factory distinguishes missing-user from
  missing-intent
- `User.paymentProvider` (default STRIPE, locked at signup for v0.1 —
  see #128)
- DB renames via `RENAME COLUMN` (preserves rows) + composite
  `@@unique([provider, providerCardId])` so Stripe `ic_*` and Privacy
  `card_*` id-spaces cannot collide
- `getPaymentProvider(providerType)` + new `getProviderForUser(userId)` /
  `getProviderForIntent(intentId)` resolvers; `NODE_ENV=test` /
  `PAYMENT_PROVIDER=mock` still short-circuits
- Callers updated end-to-end: routes (agent, approvals, intents,
  webhooks), ledger/potService (currency from intent), orchestrator,
  telegram callback/menu, worker cancelCardProcessor
- Validator default currency `gbp` → `eur`

**`test`**
- Existing suites updated for the rename
- New `stripeProvider.test.ts` pinning provider metadata
- `providerFactory.test.ts` covers per-type caching, mock toggle, and
  the new resolvers (UserNotFoundError vs IntentNotFoundError)
- Telegram tests assert resolver-specific calls (intent-scoped flows
  must use `getProviderForIntent`, not a hardcoded id)

**`test` (defensive extras for round-3 corner cases)**
- Symmetric "rethrows non-P2025" test for `getProviderForIntent`
- New `postCheckoutCancelPolicy.test.ts` covering the AFTER_TTL branch:
  `cardTtlMinutes` of 0 / negative / positive / null

## Deferred to #106

`PRIVACY_COM` enum value, `PrivacyComProvider` impl,
`/v1/webhooks/privacy` route, signup UX presenting the provider choice,
orchestrator hooks for SINGLE_USE auto-cancel.

## Test plan

- [x] `npm test -- --testPathPattern=tests/unit` — 379 pass
- [x] `npx tsc --noEmit` — clean
- [ ] `npm run test:integration` — needs CI's real `STRIPE_SECRET_KEY`
      for the Stripe-backed e2e suites

## Notes for review

CodeRabbit's findings on #129 round 3 were addressed in the round-3
commit on the old branch — that final tree is what's replayed here, so
they're already in. The Privacy.com files comments on #129 were
deferred there and remain deferred (#106).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for payment provider abstraction to enable future provider expansion
  * Currency is now automatically derived from user payment settings instead of requiring per-request specification

* **Bug Fixes**
  * Enhanced error handling for missing user and intent scenarios
  * Improved webhook validation and processing

* **Refactor**
  * Restructured payment provider initialization and resolution logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->