### PR TITLE
feat(issue-163): unify Telegram into single channel with ephemeral setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,9 +18,4 @@ LOG_LEVEL=info
 # Telegram (optional) — see docs/telegram-setup.md
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_WEBHOOK_SECRET=
-TELEGRAM_TEST_CHAT_ID=
-# Separate Telegram group/channel for integration test messages (keeps your main bot chat clean).
-# Create a private Telegram group with yourself + the bot, then set its chat ID here.
-# Live integration tests will use this channel instead of TELEGRAM_TEST_CHAT_ID when set.
-TELEGRAM_TEST_CHANNEL_ID=
 TELEGRAM_MOCK=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ npm install
 # Database
 npm run db:migrate              # run pending migrations
 npm run db:reset                # reset and re-migrate (dev only)
-npm run seed                    # create demo@agentpay.dev (set TELEGRAM_TEST_CHANNEL_ID or TELEGRAM_TEST_CHAT_ID in .env to pre-link Telegram)
+npm run seed                    # create demo@agentpay.dev (link Telegram via /start <code> per docs/telegram-setup.md)
 npx prisma studio               # browse DB in browser
 
 # Dev
@@ -134,8 +134,6 @@ STRIPE_WEBHOOK_SECRET=whsec_...
 WORKER_API_KEY=local-dev-worker-key
 TELEGRAM_BOT_TOKEN=...
 TELEGRAM_WEBHOOK_SECRET=...
-TELEGRAM_TEST_CHAT_ID=        # optional, local dev only — your main bot DM chat ID
-TELEGRAM_TEST_CHANNEL_ID=     # optional, local dev only — separate group for integration test messages
 PORT=3000
 ```
 

--- a/README.md
+++ b/README.md
@@ -545,8 +545,6 @@ Copy `.env.example` to `.env` and fill in:
 | `WORKER_API_KEY` | Yes | `local-dev-worker-key` | Shared secret for agent endpoints |
 | `TELEGRAM_BOT_TOKEN` | No | — | Telegram bot token from @BotFather |
 | `TELEGRAM_WEBHOOK_SECRET` | No | — | Secret token for Telegram webhook verification |
-| `TELEGRAM_TEST_CHAT_ID` | No | — | Chat ID for local integration smoke tests (main bot DM) |
-| `TELEGRAM_TEST_CHANNEL_ID` | No | — | Chat ID of a separate Telegram group for integration test messages; routes live test traffic away from the main bot DM |
 | `PORT` | No | `3000` | HTTP listen port |
 | `NODE_ENV` | No | `development` | `development` / `test` / `production` |
 

--- a/docs/telegram-setup.md
+++ b/docs/telegram-setup.md
@@ -1,16 +1,8 @@
 # Telegram Approval Setup
 
-This guide sets up the Telegram bot so users can approve or reject purchase requests from their phone.
+This guide sets up the Telegram bot so users can approve or reject purchase requests from their phone. There is one onboarding path: every user — including local testers — pairs via `/start <code>` in Telegram.
 
-There are **two testing paths** — Steps 1–4 are shared, then you choose:
-
-| | Path A — Seeded user | Path B — Full OpenClaw |
-|---|---|---|
-| **Best for** | Solo testing, no OpenClaw running | End-to-end integration testing |
-| **User created by** | `npm run seed` or `link-telegram` endpoint | OpenClaw pairing flow |
-| **Requires OpenClaw?** | No | Yes |
-
-Steps 1–4 (bot, ngrok, webhook) are identical for both paths. At Step 5, choose the path that fits your situation.
+> **Setup messages are ephemeral.** During signup the bot sends a few prompts (confirmation, email, success/API key). Once signup completes successfully, all of these messages are deleted automatically so the chat retains only operational notifications (approval requests, the main menu). **Save your API key immediately** — it is shown once, then the message is removed.
 
 See [docs/openclaw.md](openclaw.md) for the full OpenClaw integration guide.
 
@@ -43,10 +35,6 @@ TELEGRAM_WEBHOOK_SECRET=<any random string you choose, e.g. my-secret-123>
 ```
 
 Restart the server after saving: `Ctrl+C` then `npm run dev`.
-
-> `TELEGRAM_TEST_CHAT_ID` is optional — used by Path A below to pre-link your Telegram account to the seeded demo user. Come back here at Path A Step 5.
-
-> `TELEGRAM_TEST_CHANNEL_ID` is optional — a **separate** chat for live integration tests (see [Test Channel Setup](#test-channel-setup) below). When set, all live test messages are routed there instead of your main bot chat, keeping the two conversations cleanly separated.
 
 ---
 
@@ -98,41 +86,44 @@ You should see: `{"ok":true,"result":true,"description":"Webhook was set"}`
 
 ---
 
-## Choose your path
+## Step 5 — Sign up via `/start <code>`
+
+Users (including local testers) are created through the OpenClaw-initiated pairing flow — **not** through any manual admin step.
+
+**What OpenClaw does (once, on first run):**
+
+```bash
+curl -X POST http://localhost:3000/v1/agent/register \
+  -H "X-Worker-Key: local-dev-worker-key"
+# → { "agentId": "ag_abc123", "pairingCode": "AB3X9K2M", "expiresAt": "..." }
+```
+
+OpenClaw stores the `agentId` permanently and gives the user the pairing code along with the bot username.
+
+**What the user does in Telegram:**
+
+1. Open the bot (search for your bot's username, e.g. `@agentpay_dev_bot`)
+2. Send: `/start AB3X9K2M` (with the code from OpenClaw)
+3. The bot shows a confirmation prompt with Confirm / Cancel buttons. Tap **Confirm**.
+4. The bot asks for your email address. Reply with it.
+5. The bot replies with your API key. **Copy it now** — it is shown once and the message is then deleted along with the rest of the signup flow. The main menu appears as the persistent landing message.
+
+After this, OpenClaw can resolve the `userId`:
+
+```bash
+curl http://localhost:3000/v1/agent/user \
+  -H "X-Worker-Key: local-dev-worker-key" \
+  -H "X-Agent-Id: ag_abc123"
+# → { "status": "claimed", "userId": "clxyz..." }
+```
+
+The pairing code is valid for 30 minutes. If it expires before the user signs up, OpenClaw calls `POST /v1/agent/register` again with `{ "agentId": "ag_abc123" }` to get a fresh code.
+
+> **Local testing without OpenClaw?** Run `npm run seed` to create the `demo@agentpay.dev` user, then call `POST /v1/agent/register` directly with `curl` to get a pairing code and complete the same `/start <code>` flow above.
 
 ---
 
-## Path A — Seeded user, no OpenClaw (fastest for solo testing)
-
-### Step 5A — Link your Telegram account to the demo user
-
-**Option 1: use `npm run seed` (recommended for first-time setup)**
-
-1. Find your Telegram chat ID. The easiest way: message [@userinfobot](https://t.me/userinfobot) and it replies with your numeric ID.
-2. Add it to `.env`:
-   ```
-   TELEGRAM_TEST_CHAT_ID=<your-numeric-chat-id>
-   ```
-3. Run the seed:
-   ```bash
-   npm run seed
-   ```
-   This upserts the `demo@agentpay.dev` user and sets `telegramChatId` to your value. The `userId` is printed to stdout — save it.
-
-**Option 2: link an existing user (skip re-seeding)**
-
-If you already have a `userId` from a prior run and just want to update the chat ID, use the `link-telegram` endpoint directly:
-
-```bash
-curl -X POST http://localhost:3000/v1/users/<userId>/link-telegram \
-  -H "Content-Type: application/json" \
-  -d '{"telegramChatId": "<your-chat-id>"}'
-# → {"userId":"...","telegramChatId":"...","linked":true}
-```
-
-Errors: `400` (missing or invalid body), `404` (userId not found — re-run `npm run seed`). No auth required.
-
-### Step 6A — Explore the menu
+## Step 6 — Explore the menu
 
 Once your account is linked, send `/menu` to the bot. You'll see an inline keyboard:
 
@@ -148,16 +139,18 @@ Once your account is linked, send `/menu` to the bot. You'll see an inline keybo
 | 📋 History | Last 5 completed purchases |
 | 🚫 Cancel Intent | Active intents you can cancel (tap one to confirm) |
 | 🔗 Agent Status | Which agent is linked to your account |
-| ⚙️ Preferences | Coming soon (card TTL / cancel policy) |
+| ⚙️ Preferences | Card TTL / cancel policy |
 
 Every screen has a ⬅️ Back button that returns to the main menu.
 
 > If you haven't signed up yet, `/menu` replies with a prompt to run `/start <code>` first.
 
-### Step 7A — Test an approval
+---
+
+## Step 7 — Test an approval
 
 ```bash
-# Create an intent (use the userId from Step 5A)
+# Create an intent (use the userId returned by GET /v1/agent/user above)
 curl -X POST http://localhost:3000/v1/intents \
   -H "Content-Type: application/json" \
   -H "X-Idempotency-Key: test-1" \
@@ -183,74 +176,6 @@ Tap ✅ Approve — the intent moves to `CHECKOUT_RUNNING` and the message updat
 
 ---
 
-## Path B — Full OpenClaw + Telegram
-
-Users are created through the OpenClaw-initiated pairing flow — **not** through any manual admin step.
-
-### Step 5B — User signup via OpenClaw
-
-**What OpenClaw does (once, on first run):**
-
-```bash
-curl -X POST http://localhost:3000/v1/agent/register \
-  -H "X-Worker-Key: local-dev-worker-key"
-# → { "agentId": "ag_abc123", "pairingCode": "AB3X9K2M", "expiresAt": "..." }
-```
-
-OpenClaw stores the `agentId` permanently and gives the user the pairing code along with the bot username.
-
-**What the user does in Telegram:**
-
-1. Open the bot (search for your bot's username, e.g. `@agentpay_dev_bot`)
-2. Send: `/start AB3X9K2M` (with the code from OpenClaw)
-3. The bot replies: *"What email address should we use for your account?"*
-4. Reply with your email address
-5. The bot confirms: *"✅ Account created! Your OpenClaw is now linked."*
-
-After this, OpenClaw can resolve the `userId`:
-
-```bash
-curl http://localhost:3000/v1/agent/user \
-  -H "X-Worker-Key: local-dev-worker-key" \
-  -H "X-Agent-Id: ag_abc123"
-# → { "status": "claimed", "userId": "clxyz..." }
-```
-
-The pairing code is valid for 30 minutes. If it expires before the user signs up, OpenClaw calls `POST /v1/agent/register` again with `{ "agentId": "ag_abc123" }` to get a fresh code.
-
-### Step 6B — Test it
-
-Once a user is signed up, create an intent and run the stub worker (same as Path A Step 6A above).
-
----
-
----
-
-## Test Channel Setup
-
-Live integration tests (e.g. `telegramApprovalCheckout`, `menuHandler.live`, `preferences.live`) send real Telegram messages. Without a dedicated test channel those messages land in your main bot conversation and clutter it.
-
-**One Telegram bot, two conversations** — a single bot can send messages to multiple chats. Create a private Telegram group that contains only you and the bot; that group gets its own chat ID and acts as an isolated test inbox.
-
-### Steps
-
-1. Open Telegram and create a new **group** (name it e.g. "AgentPay — Integration Tests").
-2. Add your bot to the group (search by its username).
-3. Find the group's chat ID. The easiest way: add [@userinfobot](https://t.me/userinfobot) to the group, it will print the group's numeric ID, then remove it. Alternatively, check the Telegram API: `GET https://api.telegram.org/bot<TOKEN>/getUpdates` after sending a message to the group.
-4. Add the ID to `.env`:
-   ```
-   TELEGRAM_TEST_CHANNEL_ID=<numeric-group-chat-id>
-   ```
-   Group chat IDs are negative numbers (e.g. `-1001234567890`).
-
-5. Restart the server: `Ctrl+C` then `npm run dev`.
-
-With `TELEGRAM_TEST_CHANNEL_ID` set, all live integration tests route to the group instead of your main bot DM. You still see the Approve/Reject buttons there and can tap them within the 60-second window — the test flow is identical.
-
-> `TELEGRAM_TEST_CHAT_ID` remains the fallback when `TELEGRAM_TEST_CHANNEL_ID` is not set, so existing setups keep working unchanged.
-
----
-
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |
@@ -262,8 +187,6 @@ With `TELEGRAM_TEST_CHANNEL_ID` set, all live integration tests route to the gro
 | Buttons do nothing | Webhook not registered or ngrok restarted | Re-run Step 4 with the current ngrok URL |
 | `401` on webhook endpoint | Wrong `TELEGRAM_WEBHOOK_SECRET` | Ensure `.env` value matches the `secret_token` in Step 4 |
 | ngrok auth error | No authtoken configured | Run `ngrok config add-authtoken <token>` |
-| `POST /v1/users/:userId/link-telegram` returns 404 | userId is wrong or DB was reset | Re-run `npm run seed` and use the printed userId |
 | `/menu` gives no response | Webhook not registered or server not running | Re-run Step 4; ensure `npm run dev` is running |
-| `/menu` says "sign up first" | No account linked to your chat ID | Run `npm run seed` (with `TELEGRAM_TEST_CHAT_ID` set) or complete the `/start <code>` flow |
-| Live tests still post to my main bot chat | `TELEGRAM_TEST_CHANNEL_ID` not set | Add the group chat ID to `.env` and restart the server |
-| Integration test messages go to the wrong chat | Wrong chat ID value | Group IDs are negative numbers; copy the exact value from `@userinfobot` |
+| `/menu` says "sign up first" | No account linked to your chat ID | Complete the `/start <code>` flow above |
+| Lost your API key | The success message was deleted as part of signup cleanup | Save the key the moment it appears. To recover: re-run `npm run seed` (rotates the demo user's key) or re-pair from a fresh `/v1/agent/register`. |

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -17,8 +17,6 @@ export const env = {
   NODE_ENV: process.env.NODE_ENV || 'development',
   TELEGRAM_BOT_TOKEN: process.env.TELEGRAM_BOT_TOKEN || '',
   TELEGRAM_WEBHOOK_SECRET: process.env.TELEGRAM_WEBHOOK_SECRET || '',
-  TELEGRAM_TEST_CHAT_ID: process.env.TELEGRAM_TEST_CHAT_ID || '',
-  TELEGRAM_TEST_CHANNEL_ID: process.env.TELEGRAM_TEST_CHANNEL_ID || '',
   TELEGRAM_MOCK: process.env.TELEGRAM_MOCK === 'true',
   PAYMENT_PROVIDER: process.env.PAYMENT_PROVIDER || 'stripe',
   LOG_LEVEL: process.env.LOG_LEVEL || 'info',

--- a/src/contracts/audit.ts
+++ b/src/contracts/audit.ts
@@ -8,4 +8,4 @@ export interface AuditEventData {
   createdAt: Date;
 }
 
-export type AgentAuditEvent = 'AGENT_LINKED' | 'AGENT_UNLINKED';
+export type AgentAuditEvent = 'AGENT_LINKED' | 'AGENT_UNLINKED' | 'TELEGRAM_SETUP_CLEANED';

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -9,13 +9,8 @@ const log = logger.child({ module: 'db/seed' });
 const prisma = new PrismaClient();
 
 async function main() {
-  // TELEGRAM_TEST_CHANNEL_ID (preferred) or TELEGRAM_TEST_CHAT_ID lets you receive real
-  // Telegram notifications without going through the full OpenClaw pairing flow.
-  // Get the chat ID by messaging @userinfobot on Telegram, then add it to .env.
-  // Re-running the seed updates the existing user.
-  const telegramChatId =
-    process.env.TELEGRAM_TEST_CHANNEL_ID || process.env.TELEGRAM_TEST_CHAT_ID || null;
-
+  // The demo user is created without a Telegram link. To receive notifications,
+  // pair via /start <code> in Telegram — see docs/telegram-setup.md.
   const rawKey = crypto.randomBytes(32).toString('hex');
   const apiKeyHash = await bcrypt.hash(rawKey, 10);
   const apiKeyPrefix = rawKey.slice(0, 16);
@@ -27,7 +22,6 @@ async function main() {
     update: {
       apiKeyHash,
       apiKeyPrefix,
-      ...(telegramChatId ? { telegramChatId } : {}),
     },
     create: {
       email: 'demo@agentpay.dev',
@@ -37,7 +31,6 @@ async function main() {
       mccAllowlist: [],
       apiKeyHash,
       apiKeyPrefix,
-      ...(telegramChatId ? { telegramChatId } : {}),
     },
   });
 
@@ -47,11 +40,7 @@ async function main() {
     );
   }
 
-  const chatIdNote = user.telegramChatId
-    ? user.telegramChatId
-    : '(not set — add TELEGRAM_TEST_CHANNEL_ID or TELEGRAM_TEST_CHAT_ID to .env and re-run seed to receive Telegram notifications)';
-
-  log.info({ userId: user.id, email: user.email, telegramChatId: chatIdNote }, 'Seeded demo user');
+  log.info({ userId: user.id, email: user.email }, 'Seeded demo user');
   console.log(`Demo user API key (save this): ${rawKey}`);
 }
 

--- a/src/telegram/mockBot.ts
+++ b/src/telegram/mockBot.ts
@@ -6,6 +6,7 @@
  *   - sendMessage
  *   - answerCallbackQuery
  *   - editMessageText
+ *   - deleteMessage
  */
 
 export interface MockCall {
@@ -61,6 +62,11 @@ const mockApi = {
       text,
       date: Math.floor(Date.now() / 1000),
     });
+  },
+
+  deleteMessage(chatId: string | number, messageId: number) {
+    record('deleteMessage', [chatId, messageId]);
+    return Promise.resolve(true);
   },
 };
 

--- a/src/telegram/sessionStore.ts
+++ b/src/telegram/sessionStore.ts
@@ -32,7 +32,9 @@ export async function clearSignupSession(chatId: number | string): Promise<void>
 }
 
 // Atomic append via RPUSH so concurrent webhook handlers for the same chat
-// cannot race and clobber each other's tracked message ids.
+// cannot race and clobber each other's tracked message ids. RPUSH and EXPIRE
+// are pipelined so a network blip between the two cannot leave an orphaned
+// list with no TTL.
 export async function appendSignupMessageId(
   chatId: number | string,
   messageId: number,
@@ -40,8 +42,7 @@ export async function appendSignupMessageId(
 ): Promise<void> {
   const redis = getRedisClient();
   const key = `${MSGS_KEY_PREFIX}${chatId}`;
-  await redis.rpush(key, String(messageId));
-  await redis.expire(key, ttlSeconds);
+  await redis.pipeline().rpush(key, String(messageId)).expire(key, ttlSeconds).exec();
 }
 
 export async function getSignupMessageIds(chatId: number | string): Promise<number[]> {

--- a/src/telegram/sessionStore.ts
+++ b/src/telegram/sessionStore.ts
@@ -1,15 +1,13 @@
 import { getRedisClient } from '@/config/redis';
 
 const KEY_PREFIX = 'telegram_signup:';
+const MSGS_KEY_PREFIX = 'telegram_signup_msgs:';
 const DEFAULT_TTL_SECONDS = 600; // 10 minutes
 
 export interface SignupSession {
   step: 'awaiting_confirmation' | 'awaiting_email';
   agentId: string;
   pairingCode: string;
-  // message_ids of every bot-sent and user-sent message during signup,
-  // bulk-deleted on success or when a stale session is replaced by a new /start.
-  messageIds?: number[];
 }
 
 export async function getSignupSession(chatId: number | string): Promise<SignupSession | null> {
@@ -30,7 +28,26 @@ export async function setSignupSession(
 
 export async function clearSignupSession(chatId: number | string): Promise<void> {
   const redis = getRedisClient();
-  await redis.del(`${KEY_PREFIX}${chatId}`);
+  await redis.del(`${KEY_PREFIX}${chatId}`, `${MSGS_KEY_PREFIX}${chatId}`);
+}
+
+// Atomic append via RPUSH so concurrent webhook handlers for the same chat
+// cannot race and clobber each other's tracked message ids.
+export async function appendSignupMessageId(
+  chatId: number | string,
+  messageId: number,
+  ttlSeconds = DEFAULT_TTL_SECONDS,
+): Promise<void> {
+  const redis = getRedisClient();
+  const key = `${MSGS_KEY_PREFIX}${chatId}`;
+  await redis.rpush(key, String(messageId));
+  await redis.expire(key, ttlSeconds);
+}
+
+export async function getSignupMessageIds(chatId: number | string): Promise<number[]> {
+  const redis = getRedisClient();
+  const ids = await redis.lrange(`${MSGS_KEY_PREFIX}${chatId}`, 0, -1);
+  return ids.map((id) => Number(id));
 }
 
 // ── Preferences session (custom TTL input) ────────────────────────────────────

--- a/src/telegram/sessionStore.ts
+++ b/src/telegram/sessionStore.ts
@@ -7,6 +7,9 @@ export interface SignupSession {
   step: 'awaiting_confirmation' | 'awaiting_email';
   agentId: string;
   pairingCode: string;
+  // message_ids of every bot-sent and user-sent message during signup,
+  // bulk-deleted on success or when a stale session is replaced by a new /start.
+  messageIds?: number[];
 }
 
 export async function getSignupSession(chatId: number | string): Promise<SignupSession | null> {

--- a/src/telegram/signupHandler.ts
+++ b/src/telegram/signupHandler.ts
@@ -31,9 +31,10 @@ async function sendEphemeral(
   opts?: SendMessageOpts,
 ): Promise<number> {
   const bot = getTelegramBot();
-  const msg = opts === undefined
-    ? await bot.api.sendMessage(chatId, text)
-    : await bot.api.sendMessage(chatId, text, opts);
+  const msg =
+    opts === undefined
+      ? await bot.api.sendMessage(chatId, text)
+      : await bot.api.sendMessage(chatId, text, opts);
   await appendSignupMessageId(chatId, msg.message_id);
   return msg.message_id;
 }
@@ -252,15 +253,17 @@ export async function handleTelegramMessage(update: Update): Promise<void> {
     await clearSignupSession(chatId);
     const deleted = await cleanupSignupMessages(chatId, finalSession);
 
-    await prisma.auditEvent.create({
-      data: {
-        intentId: null,
-        actor: result.user.id,
-        agentId: session.agentId,
-        event: 'TELEGRAM_SETUP_CLEANED',
-        payload: { messageCount: deleted },
-      },
-    }).catch((err) => log.error({ err }, 'Failed to record TELEGRAM_SETUP_CLEANED audit event'));
+    await prisma.auditEvent
+      .create({
+        data: {
+          intentId: null,
+          actor: result.user.id,
+          agentId: session.agentId,
+          event: 'TELEGRAM_SETUP_CLEANED',
+          payload: { messageCount: deleted },
+        },
+      })
+      .catch((err) => log.error({ err }, 'Failed to record TELEGRAM_SETUP_CLEANED audit event'));
 
     await sendMainMenu(chatId);
   } catch (err: any) {

--- a/src/telegram/signupHandler.ts
+++ b/src/telegram/signupHandler.ts
@@ -3,6 +3,7 @@ import { InlineKeyboard } from 'grammy';
 import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
 import { prisma } from '@/db/client';
+import { logger } from '@/config/logger';
 import { getTelegramBot } from './telegramClient';
 import {
   getSignupSession,
@@ -10,9 +11,65 @@ import {
   clearSignupSession,
   getPrefSession,
   clearPrefSession,
+  type SignupSession,
 } from './sessionStore';
 import { sendMainMenu } from './menuHandler';
 import { CardCancelPolicy } from '@/contracts';
+
+const log = logger.child({ module: 'telegram/signupHandler' });
+
+type SendMessageOpts = Parameters<ReturnType<typeof getTelegramBot>['api']['sendMessage']>[2];
+
+/**
+ * Sends a message and records its message_id in the active signup session
+ * so it can be deleted on completion. If no session exists, falls back to a
+ * plain sendMessage (the message simply won't be tracked for cleanup).
+ */
+async function sendEphemeral(
+  chatId: number,
+  text: string,
+  opts?: SendMessageOpts,
+): Promise<number> {
+  const bot = getTelegramBot();
+  const msg = opts === undefined
+    ? await bot.api.sendMessage(chatId, text)
+    : await bot.api.sendMessage(chatId, text, opts);
+  await appendSignupMessageId(chatId, msg.message_id);
+  return msg.message_id;
+}
+
+async function appendSignupMessageId(chatId: number, messageId: number): Promise<void> {
+  const session = await getSignupSession(chatId);
+  if (!session) return;
+  await setSignupSession(chatId, {
+    ...session,
+    messageIds: [...(session.messageIds ?? []), messageId],
+  });
+}
+
+/**
+ * Best-effort bulk delete of all setup messages tracked on a session.
+ * Per-id failures are swallowed so a single error doesn't abort the rest.
+ * Telegram only allows bots to delete messages within the last 48h; the 10-min
+ * session TTL keeps us well inside that window.
+ */
+async function cleanupSignupMessages(
+  chatId: number,
+  session: Pick<SignupSession, 'messageIds'> | null,
+): Promise<number> {
+  const bot = getTelegramBot();
+  const ids = session?.messageIds ?? [];
+  let deleted = 0;
+  for (const id of ids) {
+    try {
+      await bot.api.deleteMessage(chatId, id);
+      deleted++;
+    } catch {
+      // ignored — already deleted, expired, or older than 48h
+    }
+  }
+  return deleted;
+}
 
 export async function handleTelegramMessage(update: Update): Promise<void> {
   const message = update.message;
@@ -55,6 +112,14 @@ export async function handleTelegramMessage(update: Update): Promise<void> {
 
   // Handle /start <code> command
   if (text.startsWith('/start')) {
+    // If a stale signup session exists from a previous abandoned attempt,
+    // clean up its tracked messages before starting fresh.
+    const stale = await getSignupSession(chatId);
+    if (stale && (stale.messageIds?.length ?? 0) > 0) {
+      await cleanupSignupMessages(chatId, stale);
+      await clearSignupSession(chatId);
+    }
+
     const parts = text.split(/\s+/);
     const code = parts[1]?.toUpperCase();
 
@@ -86,17 +151,20 @@ export async function handleTelegramMessage(update: Update): Promise<void> {
       return;
     }
 
+    // Initialize session with the user's /start message id already tracked,
+    // so the chat is fully cleaned up at the end.
     await setSignupSession(chatId, {
       step: 'awaiting_confirmation',
       agentId: pairingCode.agentId,
       pairingCode: code,
+      messageIds: [message.message_id],
     });
 
     const keyboard = new InlineKeyboard()
       .text('✅ Confirm', 'link_confirm:_')
       .text('❌ Cancel', 'link_cancel:_');
 
-    await bot.api.sendMessage(
+    await sendEphemeral(
       chatId,
       `🤖 Agent <code>${pairingCode.agentId}</code> wants to link to your account.\n\nDo you want to proceed?`,
       { parse_mode: 'HTML', reply_markup: keyboard },
@@ -111,11 +179,11 @@ export async function handleTelegramMessage(update: Update): Promise<void> {
     return;
   }
 
+  // Track the user's incoming message for later cleanup, regardless of branch.
+  await appendSignupMessageId(chatId, message.message_id);
+
   if (session.step === 'awaiting_confirmation') {
-    await bot.api.sendMessage(
-      chatId,
-      'Please use the buttons above to confirm or cancel the linking.',
-    );
+    await sendEphemeral(chatId, 'Please use the buttons above to confirm or cancel the linking.');
     return;
   }
 
@@ -123,7 +191,7 @@ export async function handleTelegramMessage(update: Update): Promise<void> {
   const email = text.toLowerCase();
 
   if (!isValidEmail(email)) {
-    await bot.api.sendMessage(chatId, "⚠️ That doesn't look like a valid email. Please try again.");
+    await sendEphemeral(chatId, "⚠️ That doesn't look like a valid email. Please try again.");
     return;
   }
 
@@ -171,13 +239,30 @@ export async function handleTelegramMessage(update: Update): Promise<void> {
       return { user, rawKey };
     });
 
-    await clearSignupSession(chatId);
-
-    await bot.api.sendMessage(
+    // Send the success/API-key message as ephemeral so its id is tracked,
+    // then bulk-delete every signup message and land the user on the main menu.
+    await sendEphemeral(
       chatId,
       `Account created! Your OpenClaw agent (<code>${session.agentId}</code>) is now linked.\n\nYour API key (save it — it won't be shown again):\n\n${result.rawKey}\n\nYou'll receive payment approval requests here.`,
       { parse_mode: 'HTML' },
     );
+
+    // Re-read the session so cleanup includes the success message id we just appended.
+    const finalSession = await getSignupSession(chatId);
+    await clearSignupSession(chatId);
+    const deleted = await cleanupSignupMessages(chatId, finalSession);
+
+    await prisma.auditEvent.create({
+      data: {
+        intentId: null,
+        actor: result.user.id,
+        agentId: session.agentId,
+        event: 'TELEGRAM_SETUP_CLEANED',
+        payload: { messageCount: deleted },
+      },
+    }).catch((err) => log.error({ err }, 'Failed to record TELEGRAM_SETUP_CLEANED audit event'));
+
+    await sendMainMenu(chatId);
   } catch (err: any) {
     if (err.name === 'PairingCodeAlreadyClaimedError') {
       await clearSignupSession(chatId);
@@ -187,7 +272,7 @@ export async function handleTelegramMessage(update: Update): Promise<void> {
       );
     } else if (err.code === 'P2002') {
       // Unique constraint — email already taken
-      await bot.api.sendMessage(
+      await sendEphemeral(
         chatId,
         '⚠️ An account with that email already exists. Please use a different email.',
       );

--- a/src/telegram/signupHandler.ts
+++ b/src/telegram/signupHandler.ts
@@ -2,6 +2,7 @@ import type { Update } from 'grammy/types';
 import { InlineKeyboard } from 'grammy';
 import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
+import { z } from 'zod';
 import { prisma } from '@/db/client';
 import { logger } from '@/config/logger';
 import { getTelegramBot } from './telegramClient';
@@ -9,22 +10,20 @@ import {
   getSignupSession,
   setSignupSession,
   clearSignupSession,
+  appendSignupMessageId,
+  getSignupMessageIds,
   getPrefSession,
   clearPrefSession,
-  type SignupSession,
 } from './sessionStore';
 import { sendMainMenu } from './menuHandler';
 import { CardCancelPolicy } from '@/contracts';
 
 const log = logger.child({ module: 'telegram/signupHandler' });
 
+const emailSchema = z.string().email().max(254);
+
 type SendMessageOpts = Parameters<ReturnType<typeof getTelegramBot>['api']['sendMessage']>[2];
 
-/**
- * Sends a message and records its message_id in the active signup session
- * so it can be deleted on completion. If no session exists, falls back to a
- * plain sendMessage (the message simply won't be tracked for cleanup).
- */
 async function sendEphemeral(
   chatId: number,
   text: string,
@@ -39,27 +38,15 @@ async function sendEphemeral(
   return msg.message_id;
 }
 
-async function appendSignupMessageId(chatId: number, messageId: number): Promise<void> {
-  const session = await getSignupSession(chatId);
-  if (!session) return;
-  await setSignupSession(chatId, {
-    ...session,
-    messageIds: [...(session.messageIds ?? []), messageId],
-  });
-}
-
 /**
- * Best-effort bulk delete of all setup messages tracked on a session.
+ * Best-effort bulk delete of all setup messages tracked for a chat.
  * Per-id failures are swallowed so a single error doesn't abort the rest.
  * Telegram only allows bots to delete messages within the last 48h; the 10-min
  * session TTL keeps us well inside that window.
  */
-async function cleanupSignupMessages(
-  chatId: number,
-  session: Pick<SignupSession, 'messageIds'> | null,
-): Promise<number> {
+async function cleanupSignupMessages(chatId: number): Promise<number> {
   const bot = getTelegramBot();
-  const ids = session?.messageIds ?? [];
+  const ids = await getSignupMessageIds(chatId);
   let deleted = 0;
   for (const id of ids) {
     try {
@@ -116,8 +103,8 @@ export async function handleTelegramMessage(update: Update): Promise<void> {
     // If a stale signup session exists from a previous abandoned attempt,
     // clean up its tracked messages before starting fresh.
     const stale = await getSignupSession(chatId);
-    if (stale && (stale.messageIds?.length ?? 0) > 0) {
-      await cleanupSignupMessages(chatId, stale);
+    if (stale) {
+      await cleanupSignupMessages(chatId);
       await clearSignupSession(chatId);
     }
 
@@ -152,14 +139,13 @@ export async function handleTelegramMessage(update: Update): Promise<void> {
       return;
     }
 
-    // Initialize session with the user's /start message id already tracked,
-    // so the chat is fully cleaned up at the end.
     await setSignupSession(chatId, {
       step: 'awaiting_confirmation',
       agentId: pairingCode.agentId,
       pairingCode: code,
-      messageIds: [message.message_id],
     });
+    // Track the user's /start message so the chat is fully cleaned up at the end.
+    await appendSignupMessageId(chatId, message.message_id);
 
     const keyboard = new InlineKeyboard()
       .text('✅ Confirm', 'link_confirm:_')
@@ -191,7 +177,7 @@ export async function handleTelegramMessage(update: Update): Promise<void> {
   // step === 'awaiting_email'
   const email = text.toLowerCase();
 
-  if (!isValidEmail(email)) {
+  if (!emailSchema.safeParse(email).success) {
     await sendEphemeral(chatId, "⚠️ That doesn't look like a valid email. Please try again.");
     return;
   }
@@ -240,18 +226,17 @@ export async function handleTelegramMessage(update: Update): Promise<void> {
       return { user, rawKey };
     });
 
-    // Send the success/API-key message as ephemeral so its id is tracked,
-    // then bulk-delete every signup message and land the user on the main menu.
-    await sendEphemeral(
+    // Bulk-delete every tracked setup message before showing the API key, so
+    // the API-key message survives cleanup and the user can copy the credential
+    // (it won't be shown again). Send it untracked.
+    const deleted = await cleanupSignupMessages(chatId);
+    await clearSignupSession(chatId);
+
+    await bot.api.sendMessage(
       chatId,
       `Account created! Your OpenClaw agent (<code>${session.agentId}</code>) is now linked.\n\nYour API key (save it — it won't be shown again):\n\n${result.rawKey}\n\nYou'll receive payment approval requests here.`,
       { parse_mode: 'HTML' },
     );
-
-    // Re-read the session so cleanup includes the success message id we just appended.
-    const finalSession = await getSignupSession(chatId);
-    await clearSignupSession(chatId);
-    const deleted = await cleanupSignupMessages(chatId, finalSession);
 
     await prisma.auditEvent
       .create({
@@ -268,6 +253,7 @@ export async function handleTelegramMessage(update: Update): Promise<void> {
     await sendMainMenu(chatId);
   } catch (err: any) {
     if (err.name === 'PairingCodeAlreadyClaimedError') {
+      await cleanupSignupMessages(chatId);
       await clearSignupSession(chatId);
       await bot.api.sendMessage(
         chatId,
@@ -283,8 +269,4 @@ export async function handleTelegramMessage(update: Update): Promise<void> {
       throw err;
     }
   }
-}
-
-function isValidEmail(email: string): boolean {
-  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 }

--- a/tests/integration/e2e/onboarding.test.ts
+++ b/tests/integration/e2e/onboarding.test.ts
@@ -17,7 +17,9 @@ import { getRedisClient, disconnectRedis } from '@/config/redis';
 // Mock Telegram outbound calls only — we don't send real Telegram messages during tests.
 // sendMessage returns an incrementing message_id so the cleanup pass has unique ids to delete.
 let _e2eMsgId = 1000;
-const mockSendMessage = jest.fn().mockImplementation(() => Promise.resolve({ message_id: ++_e2eMsgId }));
+const mockSendMessage = jest
+  .fn()
+  .mockImplementation(() => Promise.resolve({ message_id: ++_e2eMsgId }));
 const mockAnswerCallbackQuery = jest.fn().mockResolvedValue(undefined);
 const mockEditMessageText = jest.fn().mockResolvedValue(undefined);
 const mockDeleteMessage = jest.fn().mockResolvedValue(true);
@@ -179,23 +181,30 @@ testSuite('OpenClaw onboarding + first purchase intent (real DB + Redis)', () =>
     await new Promise((r) => setTimeout(r, 300));
 
     // Bot should have confirmed account creation (message includes API key)
-    expect(mockSendMessage).toHaveBeenCalledWith(chatId, expect.stringContaining('Account created'), expect.any(Object));
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      chatId,
+      expect.stringContaining('Account created'),
+      expect.any(Object),
+    );
 
     // Cleanup should have deleted every tracked setup message after the success message was sent.
     // At minimum: the user's /start message, the bot confirmation, the user's email reply, and the success message.
     expect(mockDeleteMessage).toHaveBeenCalled();
     expect(mockDeleteMessage.mock.calls.length).toBeGreaterThanOrEqual(4);
     const lastSendOrder = Math.max(
-      ...mockSendMessage.mock.invocationCallOrder.filter((_, i) =>
-        typeof mockSendMessage.mock.calls[i][1] === 'string' &&
-        (mockSendMessage.mock.calls[i][1] as string).includes('Account created'),
+      ...mockSendMessage.mock.invocationCallOrder.filter(
+        (_, i) =>
+          typeof mockSendMessage.mock.calls[i][1] === 'string' &&
+          (mockSendMessage.mock.calls[i][1] as string).includes('Account created'),
       ),
     );
     const firstDeleteOrder = mockDeleteMessage.mock.invocationCallOrder[0];
     expect(firstDeleteOrder).toBeGreaterThan(lastSendOrder);
 
     // TELEGRAM_SETUP_CLEANED audit event should have been emitted alongside AGENT_LINKED
-    const auditEvents = await prisma.auditEvent.findMany({ where: { event: 'TELEGRAM_SETUP_CLEANED' } });
+    const auditEvents = await prisma.auditEvent.findMany({
+      where: { event: 'TELEGRAM_SETUP_CLEANED' },
+    });
     expect(auditEvents.length).toBe(1);
 
     // Verify user exists in DB with correct fields

--- a/tests/integration/e2e/onboarding.test.ts
+++ b/tests/integration/e2e/onboarding.test.ts
@@ -12,18 +12,22 @@
 import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
 import { prisma } from '@/db/client';
-import { getRedisClient } from '@/config/redis';
+import { getRedisClient, disconnectRedis } from '@/config/redis';
 
-// Mock Telegram outbound calls only — we don't send real Telegram messages during tests
-const mockSendMessage = jest.fn().mockResolvedValue({ message_id: 1 });
+// Mock Telegram outbound calls only — we don't send real Telegram messages during tests.
+// sendMessage returns an incrementing message_id so the cleanup pass has unique ids to delete.
+let _e2eMsgId = 1000;
+const mockSendMessage = jest.fn().mockImplementation(() => Promise.resolve({ message_id: ++_e2eMsgId }));
 const mockAnswerCallbackQuery = jest.fn().mockResolvedValue(undefined);
 const mockEditMessageText = jest.fn().mockResolvedValue(undefined);
+const mockDeleteMessage = jest.fn().mockResolvedValue(true);
 jest.mock('@/telegram/telegramClient', () => ({
   getTelegramBot: () => ({
     api: {
       sendMessage: mockSendMessage,
       answerCallbackQuery: mockAnswerCallbackQuery,
       editMessageText: mockEditMessageText,
+      deleteMessage: mockDeleteMessage,
     },
   }),
 }));
@@ -52,7 +56,7 @@ beforeAll(async () => {
 afterAll(async () => {
   await app.close();
   await prisma.$disconnect();
-  getRedisClient().disconnect();
+  disconnectRedis();
 });
 
 beforeEach(async () => {
@@ -175,11 +179,24 @@ testSuite('OpenClaw onboarding + first purchase intent (real DB + Redis)', () =>
     await new Promise((r) => setTimeout(r, 300));
 
     // Bot should have confirmed account creation (message includes API key)
-    expect(mockSendMessage).toHaveBeenLastCalledWith(
-      chatId,
-      expect.stringContaining('Account created'),
-      expect.any(Object),
+    expect(mockSendMessage).toHaveBeenCalledWith(chatId, expect.stringContaining('Account created'), expect.any(Object));
+
+    // Cleanup should have deleted every tracked setup message after the success message was sent.
+    // At minimum: the user's /start message, the bot confirmation, the user's email reply, and the success message.
+    expect(mockDeleteMessage).toHaveBeenCalled();
+    expect(mockDeleteMessage.mock.calls.length).toBeGreaterThanOrEqual(4);
+    const lastSendOrder = Math.max(
+      ...mockSendMessage.mock.invocationCallOrder.filter((_, i) =>
+        typeof mockSendMessage.mock.calls[i][1] === 'string' &&
+        (mockSendMessage.mock.calls[i][1] as string).includes('Account created'),
+      ),
     );
+    const firstDeleteOrder = mockDeleteMessage.mock.invocationCallOrder[0];
+    expect(firstDeleteOrder).toBeGreaterThan(lastSendOrder);
+
+    // TELEGRAM_SETUP_CLEANED audit event should have been emitted alongside AGENT_LINKED
+    const auditEvents = await prisma.auditEvent.findMany({ where: { event: 'TELEGRAM_SETUP_CLEANED' } });
+    expect(auditEvents.length).toBe(1);
 
     // Verify user exists in DB with correct fields
     const user = await prisma.user.findUnique({ where: { email: testEmail } });

--- a/tests/integration/e2e/telegramApprovalCheckout.test.ts
+++ b/tests/integration/e2e/telegramApprovalCheckout.test.ts
@@ -81,13 +81,19 @@ testSuite('Telegram approval -> Stripe Issuing checkout', () => {
   });
 
   afterAll(async () => {
-    await prisma.virtualCard.deleteMany({ where: { intentId } });
-    await prisma.ledgerEntry.deleteMany({ where: { intentId } });
-    await prisma.pot.deleteMany({ where: { intentId } });
-    await prisma.approvalDecision.deleteMany({ where: { intentId } });
-    await prisma.auditEvent.deleteMany({ where: { intentId } });
-    await prisma.purchaseIntent.deleteMany({ where: { id: intentId } });
-    await prisma.user.deleteMany({ where: { id: userId } });
+    // Guard against `undefined` intentId/userId producing unfiltered deletes
+    // when a beforeAll fails before either is assigned.
+    if (intentId) {
+      await prisma.virtualCard.deleteMany({ where: { intentId } });
+      await prisma.ledgerEntry.deleteMany({ where: { intentId } });
+      await prisma.pot.deleteMany({ where: { intentId } });
+      await prisma.approvalDecision.deleteMany({ where: { intentId } });
+      await prisma.auditEvent.deleteMany({ where: { intentId } });
+      await prisma.purchaseIntent.deleteMany({ where: { id: intentId } });
+    }
+    if (userId) {
+      await prisma.user.deleteMany({ where: { id: userId } });
+    }
   });
 
   // -- Step 1 -- Create test user ---------------------------------------------

--- a/tests/integration/e2e/telegramApprovalCheckout.test.ts
+++ b/tests/integration/e2e/telegramApprovalCheckout.test.ts
@@ -42,8 +42,7 @@ const stripeCtx = createStripeProvider();
 const hasStripeKey = process.env.STRIPE_SECRET_KEY?.startsWith('sk_test_');
 const isMockMode = process.env.TELEGRAM_MOCK === 'true' || !process.env.TELEGRAM_BOT_TOKEN;
 const hasTelegram =
-  isMockMode ||
-  (!!process.env.TELEGRAM_BOT_TOKEN && !!process.env.TELEGRAM_TEST_CHAT_ID);
+  isMockMode || (!!process.env.TELEGRAM_BOT_TOKEN && !!process.env.TELEGRAM_TEST_CHAT_ID);
 
 const testSuite = hasStripeKey && hasTelegram ? describe : describe.skip;
 
@@ -62,9 +61,7 @@ const APPROVAL_TIMEOUT_MS = 60_000;
 const POLL_INTERVAL_MS = 2_000;
 
 // Use a synthetic chat ID in mock mode; otherwise the chat to send the test message to
-const TEST_CHAT_ID = isMockMode
-  ? '999999999'
-  : process.env.TELEGRAM_TEST_CHAT_ID!;
+const TEST_CHAT_ID = isMockMode ? '999999999' : process.env.TELEGRAM_TEST_CHAT_ID!;
 
 // -- Teardown -----------------------------------------------------------------
 afterAll(async () => {

--- a/tests/integration/e2e/telegramApprovalCheckout.test.ts
+++ b/tests/integration/e2e/telegramApprovalCheckout.test.ts
@@ -43,8 +43,7 @@ const hasStripeKey = process.env.STRIPE_SECRET_KEY?.startsWith('sk_test_');
 const isMockMode = process.env.TELEGRAM_MOCK === 'true' || !process.env.TELEGRAM_BOT_TOKEN;
 const hasTelegram =
   isMockMode ||
-  (!!process.env.TELEGRAM_BOT_TOKEN &&
-    !!(process.env.TELEGRAM_TEST_CHANNEL_ID || process.env.TELEGRAM_TEST_CHAT_ID));
+  (!!process.env.TELEGRAM_BOT_TOKEN && !!process.env.TELEGRAM_TEST_CHAT_ID);
 
 const testSuite = hasStripeKey && hasTelegram ? describe : describe.skip;
 
@@ -62,10 +61,10 @@ const CURRENCY = 'eur';
 const APPROVAL_TIMEOUT_MS = 60_000;
 const POLL_INTERVAL_MS = 2_000;
 
-// Use a synthetic chat ID in mock mode; prefer the dedicated test channel over the main chat
+// Use a synthetic chat ID in mock mode; otherwise the chat to send the test message to
 const TEST_CHAT_ID = isMockMode
   ? '999999999'
-  : (process.env.TELEGRAM_TEST_CHANNEL_ID || process.env.TELEGRAM_TEST_CHAT_ID)!;
+  : process.env.TELEGRAM_TEST_CHAT_ID!;
 
 // -- Teardown -----------------------------------------------------------------
 afterAll(async () => {

--- a/tests/integration/telegram/connectionFlow.test.ts
+++ b/tests/integration/telegram/connectionFlow.test.ts
@@ -21,9 +21,7 @@
  */
 
 const TELEGRAM_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
-// Prefer the dedicated test channel to keep the main bot chat uncluttered
-const TELEGRAM_TEST_CHAT_ID =
-  process.env.TELEGRAM_TEST_CHANNEL_ID || process.env.TELEGRAM_TEST_CHAT_ID;
+const TELEGRAM_TEST_CHAT_ID = process.env.TELEGRAM_TEST_CHAT_ID;
 const isMockEnv = process.env.TELEGRAM_MOCK === 'true';
 
 const describeIfTelegram = TELEGRAM_TOKEN && !isMockEnv ? describe : describe.skip;
@@ -144,7 +142,7 @@ describeIfTelegram('Telegram Bot API infrastructure', () => {
           }
         : () => {
             console.log(
-              'Step 3.1 skipped — set TELEGRAM_TEST_CHANNEL_ID or TELEGRAM_TEST_CHAT_ID in .env to enable',
+              'Step 3.1 skipped — set TELEGRAM_TEST_CHAT_ID in .env to enable',
             );
           },
     );

--- a/tests/integration/telegram/connectionFlow.test.ts
+++ b/tests/integration/telegram/connectionFlow.test.ts
@@ -141,9 +141,7 @@ describeIfTelegram('Telegram Bot API infrastructure', () => {
             );
           }
         : () => {
-            console.log(
-              'Step 3.1 skipped — set TELEGRAM_TEST_CHAT_ID in .env to enable',
-            );
+            console.log('Step 3.1 skipped — set TELEGRAM_TEST_CHAT_ID in .env to enable');
           },
     );
 

--- a/tests/integration/telegram/menuHandler.live.test.ts
+++ b/tests/integration/telegram/menuHandler.live.test.ts
@@ -43,9 +43,9 @@ import type { FastifyInstance } from 'fastify';
 // ── Environment ───────────────────────────────────────────────────────────────
 
 const TELEGRAM_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
-// Prefer the dedicated test channel to keep the main bot chat uncluttered
-const _testChatIdRaw = process.env.TELEGRAM_TEST_CHANNEL_ID || process.env.TELEGRAM_TEST_CHAT_ID;
-const TEST_CHAT_ID = _testChatIdRaw ? parseInt(_testChatIdRaw, 10) : null;
+const TEST_CHAT_ID = process.env.TELEGRAM_TEST_CHAT_ID
+  ? parseInt(process.env.TELEGRAM_TEST_CHAT_ID, 10)
+  : null;
 const TELEGRAM_SECRET = process.env.TELEGRAM_WEBHOOK_SECRET ?? 'ilovedatadogok';
 const BASE = `https://api.telegram.org/bot${TELEGRAM_TOKEN}`;
 const isMockEnv = process.env.TELEGRAM_MOCK === 'true';
@@ -137,7 +137,9 @@ async function waitForCallback(
     for (const update of result.result ?? []) {
       updateOffset = update.update_id + 1;
       const cb = update.callback_query;
-      if (!cb || cb.from.id !== TEST_CHAT_ID) continue;
+      // Filter by chat.id (not from.id) — in a group chat, from.id is the
+      // tapping user's personal ID, while chat.id is the group ID we expect.
+      if (!cb || cb.message?.chat?.id !== TEST_CHAT_ID) continue;
 
       const colonIdx = (cb.data ?? '').indexOf(':');
       const action = cb.data.slice(0, colonIdx);
@@ -154,10 +156,13 @@ async function waitForCallback(
         };
       }
 
-      // Wrong button — alert user and keep waiting
+      // Wrong button — alert user and keep waiting. The instruction message
+      // sent just before is the most recent message in the chat (i.e. shown
+      // BELOW the keyboard), so point there instead of leaking internal
+      // callback_data identifiers.
       await tgPost('answerCallbackQuery', {
         callback_query_id: cb.id,
-        text: `⚠️ Please tap: ${allowed.join(' or ')}`,
+        text: '⚠️ Please tap the button named in the instruction below 👇',
         show_alert: true,
       });
     }

--- a/tests/integration/telegram/preferences.live.test.ts
+++ b/tests/integration/telegram/preferences.live.test.ts
@@ -41,9 +41,9 @@ import type { FastifyInstance } from 'fastify';
 // ── Environment ───────────────────────────────────────────────────────────────
 
 const TELEGRAM_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
-// Prefer the dedicated test channel to keep the main bot chat uncluttered
-const _testChatIdRaw = process.env.TELEGRAM_TEST_CHANNEL_ID || process.env.TELEGRAM_TEST_CHAT_ID;
-const TEST_CHAT_ID = _testChatIdRaw ? parseInt(_testChatIdRaw, 10) : null;
+const TEST_CHAT_ID = process.env.TELEGRAM_TEST_CHAT_ID
+  ? parseInt(process.env.TELEGRAM_TEST_CHAT_ID, 10)
+  : null;
 const TELEGRAM_SECRET = process.env.TELEGRAM_WEBHOOK_SECRET ?? 'ilovedatadogok';
 const BASE = `https://api.telegram.org/bot${TELEGRAM_TOKEN}`;
 const isMockEnv = process.env.TELEGRAM_MOCK === 'true';
@@ -134,7 +134,9 @@ async function waitForCallback(
     for (const update of result.result ?? []) {
       updateOffset = update.update_id + 1;
       const cb = update.callback_query;
-      if (!cb || cb.from.id !== TEST_CHAT_ID) continue;
+      // Filter by chat.id (not from.id) — in a group chat, from.id is the
+      // tapping user's personal ID, while chat.id is the group ID we expect.
+      if (!cb || cb.message?.chat?.id !== TEST_CHAT_ID) continue;
 
       const colonIdx = (cb.data ?? '').indexOf(':');
       const action = cb.data.slice(0, colonIdx);
@@ -151,10 +153,13 @@ async function waitForCallback(
         };
       }
 
-      // Wrong button — alert user and keep waiting
+      // Wrong button — alert user and keep waiting. The instruction message
+      // sent just before is the most recent message in the chat (i.e. shown
+      // BELOW the keyboard), so point there instead of leaking internal
+      // callback_data identifiers.
       await tgPost('answerCallbackQuery', {
         callback_query_id: cb.id,
-        text: `⚠️ Please tap: ${allowed.join(' or ')}`,
+        text: '⚠️ Please tap the button named in the instruction below 👇',
         show_alert: true,
       });
     }
@@ -196,7 +201,7 @@ async function waitForTextMessage(
       const msg = update.message;
       if (
         msg &&
-        msg.from?.id === TEST_CHAT_ID &&
+        msg.chat?.id === TEST_CHAT_ID &&
         typeof msg.text === 'string' &&
         !msg.text.startsWith('/')
       ) {

--- a/tests/unit/api/rateLimit.test.ts
+++ b/tests/unit/api/rateLimit.test.ts
@@ -23,8 +23,6 @@ jest.mock('@/config/env', () => ({
     REDIS_URL: 'redis://localhost:6379',
     TELEGRAM_BOT_TOKEN: '',
     TELEGRAM_WEBHOOK_SECRET: 'test-telegram-secret',
-    TELEGRAM_TEST_CHAT_ID: '',
-    TELEGRAM_TEST_CHANNEL_ID: '',
     TELEGRAM_MOCK: false,
     PAYMENT_PROVIDER: 'stripe',
   },

--- a/tests/unit/api/telegram.test.ts
+++ b/tests/unit/api/telegram.test.ts
@@ -9,8 +9,6 @@ jest.mock('@/config/env', () => ({
     REDIS_URL: 'redis://localhost:6379',
     TELEGRAM_BOT_TOKEN: 'test-bot-token',
     TELEGRAM_WEBHOOK_SECRET: 'test-webhook-secret',
-    TELEGRAM_TEST_CHAT_ID: '',
-    TELEGRAM_TEST_CHANNEL_ID: '',
   },
 }));
 

--- a/tests/unit/telegram/callbackHandler.test.ts
+++ b/tests/unit/telegram/callbackHandler.test.ts
@@ -9,8 +9,6 @@ jest.mock('@/config/env', () => ({
     NODE_ENV: 'test',
     STRIPE_SECRET_KEY: 'sk_test_placeholder',
     STRIPE_WEBHOOK_SECRET: 'whsec_placeholder',
-    TELEGRAM_TEST_CHAT_ID: '',
-    TELEGRAM_TEST_CHANNEL_ID: '',
   },
 }));
 

--- a/tests/unit/telegram/notificationService.test.ts
+++ b/tests/unit/telegram/notificationService.test.ts
@@ -9,8 +9,6 @@ jest.mock('@/config/env', () => ({
     NODE_ENV: 'test',
     STRIPE_SECRET_KEY: 'sk_test_placeholder',
     STRIPE_WEBHOOK_SECRET: 'whsec_placeholder',
-    TELEGRAM_TEST_CHAT_ID: '',
-    TELEGRAM_TEST_CHANNEL_ID: '',
   },
 }));
 

--- a/tests/unit/telegram/signupHandler.test.ts
+++ b/tests/unit/telegram/signupHandler.test.ts
@@ -28,16 +28,25 @@ jest.mock('@/db/client', () => ({
   },
 }));
 
-// Mock Telegram bot
-const mockSendMessage = jest.fn().mockResolvedValue({ message_id: 1 });
+// Mock Telegram bot — sendMessage returns an incrementing message_id so tests
+// can assert which ids end up in the cleanup queue.
+let _mockMsgId = 100;
+const mockSendMessage = jest.fn().mockImplementation(() => Promise.resolve({ message_id: ++_mockMsgId }));
+const mockDeleteMessage = jest.fn().mockResolvedValue(true);
 jest.mock('@/telegram/telegramClient', () => ({
-  getTelegramBot: () => ({ api: { sendMessage: mockSendMessage } }),
+  getTelegramBot: () => ({ api: { sendMessage: mockSendMessage, deleteMessage: mockDeleteMessage } }),
 }));
 
-// Mock session store
-const mockGetSession = jest.fn();
-const mockSetSession = jest.fn();
-const mockClearSession = jest.fn();
+// Mock session store — back the get/set with an in-memory map so the helpers
+// in signupHandler.ts (which read-modify-write the session) behave realistically.
+const sessionMap = new Map<string, any>();
+const mockGetSession = jest.fn(async (chatId: number | string) => sessionMap.get(String(chatId)) ?? null);
+const mockSetSession = jest.fn(async (chatId: number | string, session: any) => {
+  sessionMap.set(String(chatId), session);
+});
+const mockClearSession = jest.fn(async (chatId: number | string) => {
+  sessionMap.delete(String(chatId));
+});
 jest.mock('@/telegram/sessionStore', () => ({
   getSignupSession: (...args: any[]) => mockGetSession(...args),
   setSignupSession: (...args: any[]) => mockSetSession(...args),
@@ -45,6 +54,11 @@ jest.mock('@/telegram/sessionStore', () => ({
   getPrefSession: jest.fn().mockResolvedValue(null),
   setPrefSession: jest.fn(),
   clearPrefSession: jest.fn(),
+}));
+
+// Mock the menu handler so success-path doesn't try to render a real menu
+jest.mock('@/telegram/menuHandler', () => ({
+  sendMainMenu: jest.fn().mockResolvedValue(undefined),
 }));
 
 import { handleTelegramMessage } from '@/telegram/signupHandler';
@@ -63,9 +77,19 @@ function makeUpdate(text: string) {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockGetSession.mockResolvedValue(null);
-  mockSetSession.mockResolvedValue(undefined);
-  mockClearSession.mockResolvedValue(undefined);
+  sessionMap.clear();
+  _mockMsgId = 100;
+  // Re-install the map-backed impls — earlier tests may have replaced them with
+  // .mockResolvedValue(constant), and jest.clearAllMocks only clears calls, not impls.
+  mockGetSession.mockImplementation(async (cid: number | string) => sessionMap.get(String(cid)) ?? null);
+  mockSetSession.mockImplementation(async (cid: number | string, session: any) => {
+    sessionMap.set(String(cid), session);
+  });
+  mockClearSession.mockImplementation(async (cid: number | string) => {
+    sessionMap.delete(String(cid));
+  });
+  mockSendMessage.mockImplementation(() => Promise.resolve({ message_id: ++_mockMsgId }));
+  mockDeleteMessage.mockResolvedValue(true);
   (mockPrisma.$transaction as jest.Mock).mockImplementation(makeTxMock(mockPrisma));
   (mockPrisma.auditEvent.create as jest.Mock).mockResolvedValue({});
 });
@@ -84,11 +108,15 @@ describe('/start <code> handling', () => {
 
     await handleTelegramMessage(makeUpdate('/start ABCD1234'));
 
-    expect(mockSetSession).toHaveBeenCalledWith(chatId, {
-      step: 'awaiting_confirmation',
-      agentId: 'ag_test',
-      pairingCode: 'ABCD1234',
-    });
+    expect(mockSetSession).toHaveBeenCalledWith(
+      chatId,
+      expect.objectContaining({
+        step: 'awaiting_confirmation',
+        agentId: 'ag_test',
+        pairingCode: 'ABCD1234',
+        messageIds: expect.arrayContaining([1]),
+      }),
+    );
     // Message should contain the agentId so the user knows what they are linking
     expect(mockSendMessage).toHaveBeenCalledWith(
       chatId,
@@ -344,5 +372,130 @@ describe('email step handling', () => {
 
     expect(mockPrisma.user.create).not.toHaveBeenCalled();
     expect(mockSendMessage).toHaveBeenCalledWith(chatId, expect.stringContaining('/start'));
+  });
+});
+
+// ─── Ephemeral setup-message cleanup ──────────────────────────────────────────
+
+describe('ephemeral setup-message cleanup', () => {
+  function userMsg(text: string, message_id: number) {
+    return { update_id: 1, message: { message_id, chat: { id: chatId }, text } } as any;
+  }
+
+  it('tracks the user /start message and the bot confirmation in messageIds', async () => {
+    (mockPrisma.pairingCode.findUnique as jest.Mock).mockResolvedValue({
+      code: 'ABCD1234',
+      agentId: 'ag_test',
+      claimedByUserId: null,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    await handleTelegramMessage(userMsg('/start ABCD1234', 7));
+
+    const stored = sessionMap.get(String(chatId));
+    expect(stored).toBeDefined();
+    expect(stored.messageIds).toEqual(expect.arrayContaining([7])); // user /start
+    expect(stored.messageIds.length).toBeGreaterThanOrEqual(2); // user + bot confirmation
+  });
+
+  it('on success, bulk-deletes every tracked setup message', async () => {
+    // Pre-populate session as if confirmation step is already done and we have
+    // accumulated message ids from the prior steps.
+    sessionMap.set(String(chatId), {
+      step: 'awaiting_email',
+      agentId: 'ag_test',
+      pairingCode: 'ABCD1234',
+      messageIds: [11, 12, 13],
+    });
+    (mockPrisma.pairingCode.findUnique as jest.Mock).mockResolvedValue({
+      code: 'ABCD1234', agentId: 'ag_test', claimedByUserId: null,
+    });
+    (mockPrisma.user.create as jest.Mock).mockResolvedValue({ id: 'user-new', email: 'alice@example.com' });
+    (mockPrisma.pairingCode.update as jest.Mock).mockResolvedValue({});
+
+    await handleTelegramMessage(userMsg('alice@example.com', 14));
+
+    // Should have deleted the original 3 ids + the user's email reply (14) + the success message
+    const deletedIds = mockDeleteMessage.mock.calls.map((c) => c[1] as number);
+    expect(deletedIds).toEqual(expect.arrayContaining([11, 12, 13, 14]));
+    expect(mockDeleteMessage.mock.calls.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('emits TELEGRAM_SETUP_CLEANED audit event with deleted count after success', async () => {
+    sessionMap.set(String(chatId), {
+      step: 'awaiting_email',
+      agentId: 'ag_test',
+      pairingCode: 'ABCD1234',
+      messageIds: [21, 22],
+    });
+    (mockPrisma.pairingCode.findUnique as jest.Mock).mockResolvedValue({
+      code: 'ABCD1234', agentId: 'ag_test', claimedByUserId: null,
+    });
+    (mockPrisma.user.create as jest.Mock).mockResolvedValue({ id: 'user-new', email: 'alice@example.com' });
+    (mockPrisma.pairingCode.update as jest.Mock).mockResolvedValue({});
+
+    await handleTelegramMessage(userMsg('alice@example.com', 23));
+
+    expect(mockPrisma.auditEvent.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        event: 'TELEGRAM_SETUP_CLEANED',
+        actor: 'user-new',
+        payload: expect.objectContaining({ messageCount: expect.any(Number) }),
+      }),
+    });
+  });
+
+  it('cleans up a stale signup session when /start arrives again', async () => {
+    sessionMap.set(String(chatId), {
+      step: 'awaiting_confirmation',
+      agentId: 'ag_old',
+      pairingCode: 'OLDCODE1',
+      messageIds: [31, 32],
+    });
+    (mockPrisma.pairingCode.findUnique as jest.Mock).mockResolvedValue({
+      code: 'NEWCODE2',
+      agentId: 'ag_new',
+      claimedByUserId: null,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    await handleTelegramMessage(userMsg('/start NEWCODE2', 33));
+
+    // Stale ids must be deleted before the new flow continues
+    const deletedIds = mockDeleteMessage.mock.calls.map((c) => c[1] as number);
+    expect(deletedIds).toEqual(expect.arrayContaining([31, 32]));
+
+    // Fresh session should NOT carry over old messageIds
+    const stored = sessionMap.get(String(chatId));
+    expect(stored.agentId).toBe('ag_new');
+    expect(stored.messageIds).not.toEqual(expect.arrayContaining([31, 32]));
+  });
+
+  it('best-effort: a failing deleteMessage does not abort subsequent deletes', async () => {
+    sessionMap.set(String(chatId), {
+      step: 'awaiting_email',
+      agentId: 'ag_test',
+      pairingCode: 'ABCD1234',
+      messageIds: [41, 42, 43],
+    });
+    (mockPrisma.pairingCode.findUnique as jest.Mock).mockResolvedValue({
+      code: 'ABCD1234', agentId: 'ag_test', claimedByUserId: null,
+    });
+    (mockPrisma.user.create as jest.Mock).mockResolvedValue({ id: 'user-new', email: 'alice@example.com' });
+    (mockPrisma.pairingCode.update as jest.Mock).mockResolvedValue({});
+
+    // Make the second delete reject
+    let callCount = 0;
+    mockDeleteMessage.mockImplementation(() => {
+      callCount++;
+      if (callCount === 2) return Promise.reject(new Error('telegram boom'));
+      return Promise.resolve(true);
+    });
+
+    await handleTelegramMessage(userMsg('alice@example.com', 44));
+
+    // All ids should have been attempted despite the middle one failing
+    const attemptedIds = mockDeleteMessage.mock.calls.map((c) => c[1] as number);
+    expect(attemptedIds).toEqual(expect.arrayContaining([41, 42, 43, 44]));
   });
 });

--- a/tests/unit/telegram/signupHandler.test.ts
+++ b/tests/unit/telegram/signupHandler.test.ts
@@ -41,9 +41,11 @@ jest.mock('@/telegram/telegramClient', () => ({
   }),
 }));
 
-// Mock session store — back the get/set with an in-memory map so the helpers
-// in signupHandler.ts (which read-modify-write the session) behave realistically.
+// Mock session store — back get/set with an in-memory map and the messageIds
+// list with a separate map (mirroring the production split into a separate
+// Redis list).
 const sessionMap = new Map<string, any>();
+const messageIdsMap = new Map<string, number[]>();
 const mockGetSession = jest.fn(
   async (chatId: number | string) => sessionMap.get(String(chatId)) ?? null,
 );
@@ -52,11 +54,23 @@ const mockSetSession = jest.fn(async (chatId: number | string, session: any) => 
 });
 const mockClearSession = jest.fn(async (chatId: number | string) => {
   sessionMap.delete(String(chatId));
+  messageIdsMap.delete(String(chatId));
 });
+const mockAppendMessageId = jest.fn(async (chatId: number | string, messageId: number) => {
+  const key = String(chatId);
+  const list = messageIdsMap.get(key) ?? [];
+  list.push(messageId);
+  messageIdsMap.set(key, list);
+});
+const mockGetMessageIds = jest.fn(
+  async (chatId: number | string) => messageIdsMap.get(String(chatId)) ?? [],
+);
 jest.mock('@/telegram/sessionStore', () => ({
   getSignupSession: (...args: any[]) => mockGetSession(...args),
   setSignupSession: (...args: any[]) => mockSetSession(...args),
   clearSignupSession: (...args: any[]) => mockClearSession(...args),
+  appendSignupMessageId: (...args: any[]) => mockAppendMessageId(...args),
+  getSignupMessageIds: (...args: any[]) => mockGetMessageIds(...args),
   getPrefSession: jest.fn().mockResolvedValue(null),
   setPrefSession: jest.fn(),
   clearPrefSession: jest.fn(),
@@ -84,6 +98,7 @@ function makeUpdate(text: string) {
 beforeEach(() => {
   jest.clearAllMocks();
   sessionMap.clear();
+  messageIdsMap.clear();
   _mockMsgId = 100;
   // Re-install the map-backed impls — earlier tests may have replaced them with
   // .mockResolvedValue(constant), and jest.clearAllMocks only clears calls, not impls.
@@ -95,7 +110,17 @@ beforeEach(() => {
   });
   mockClearSession.mockImplementation(async (cid: number | string) => {
     sessionMap.delete(String(cid));
+    messageIdsMap.delete(String(cid));
   });
+  mockAppendMessageId.mockImplementation(async (cid: number | string, messageId: number) => {
+    const key = String(cid);
+    const list = messageIdsMap.get(key) ?? [];
+    list.push(messageId);
+    messageIdsMap.set(key, list);
+  });
+  mockGetMessageIds.mockImplementation(
+    async (cid: number | string) => messageIdsMap.get(String(cid)) ?? [],
+  );
   mockSendMessage.mockImplementation(() => Promise.resolve({ message_id: ++_mockMsgId }));
   mockDeleteMessage.mockResolvedValue(true);
   (mockPrisma.$transaction as jest.Mock).mockImplementation(makeTxMock(mockPrisma));
@@ -122,9 +147,10 @@ describe('/start <code> handling', () => {
         step: 'awaiting_confirmation',
         agentId: 'ag_test',
         pairingCode: 'ABCD1234',
-        messageIds: expect.arrayContaining([1]),
       }),
     );
+    // The /start message id is tracked separately for ephemeral cleanup.
+    expect(mockAppendMessageId).toHaveBeenCalledWith(chatId, 1);
     // Message should contain the agentId so the user knows what they are linking
     expect(mockSendMessage).toHaveBeenCalledWith(
       chatId,
@@ -400,10 +426,10 @@ describe('ephemeral setup-message cleanup', () => {
 
     await handleTelegramMessage(userMsg('/start ABCD1234', 7));
 
-    const stored = sessionMap.get(String(chatId));
-    expect(stored).toBeDefined();
-    expect(stored.messageIds).toEqual(expect.arrayContaining([7])); // user /start
-    expect(stored.messageIds.length).toBeGreaterThanOrEqual(2); // user + bot confirmation
+    expect(sessionMap.get(String(chatId))).toBeDefined();
+    const tracked = messageIdsMap.get(String(chatId)) ?? [];
+    expect(tracked).toEqual(expect.arrayContaining([7])); // user /start
+    expect(tracked.length).toBeGreaterThanOrEqual(2); // user + bot confirmation
   });
 
   it('on success, bulk-deletes every tracked setup message', async () => {
@@ -413,8 +439,8 @@ describe('ephemeral setup-message cleanup', () => {
       step: 'awaiting_email',
       agentId: 'ag_test',
       pairingCode: 'ABCD1234',
-      messageIds: [11, 12, 13],
     });
+    messageIdsMap.set(String(chatId), [11, 12, 13]);
     (mockPrisma.pairingCode.findUnique as jest.Mock).mockResolvedValue({
       code: 'ABCD1234',
       agentId: 'ag_test',
@@ -428,10 +454,11 @@ describe('ephemeral setup-message cleanup', () => {
 
     await handleTelegramMessage(userMsg('alice@example.com', 14));
 
-    // Should have deleted the original 3 ids + the user's email reply (14) + the success message
+    // Cleanup deletes the 3 prior tracked ids + the user's email reply (14).
+    // The API-key success message is intentionally NOT tracked so the user can copy it.
     const deletedIds = mockDeleteMessage.mock.calls.map((c) => c[1] as number);
     expect(deletedIds).toEqual(expect.arrayContaining([11, 12, 13, 14]));
-    expect(mockDeleteMessage.mock.calls.length).toBeGreaterThanOrEqual(5);
+    expect(mockDeleteMessage.mock.calls.length).toBe(4);
   });
 
   it('emits TELEGRAM_SETUP_CLEANED audit event with deleted count after success', async () => {
@@ -439,8 +466,8 @@ describe('ephemeral setup-message cleanup', () => {
       step: 'awaiting_email',
       agentId: 'ag_test',
       pairingCode: 'ABCD1234',
-      messageIds: [21, 22],
     });
+    messageIdsMap.set(String(chatId), [21, 22]);
     (mockPrisma.pairingCode.findUnique as jest.Mock).mockResolvedValue({
       code: 'ABCD1234',
       agentId: 'ag_test',
@@ -468,8 +495,8 @@ describe('ephemeral setup-message cleanup', () => {
       step: 'awaiting_confirmation',
       agentId: 'ag_old',
       pairingCode: 'OLDCODE1',
-      messageIds: [31, 32],
     });
+    messageIdsMap.set(String(chatId), [31, 32]);
     (mockPrisma.pairingCode.findUnique as jest.Mock).mockResolvedValue({
       code: 'NEWCODE2',
       agentId: 'ag_new',
@@ -486,7 +513,8 @@ describe('ephemeral setup-message cleanup', () => {
     // Fresh session should NOT carry over old messageIds
     const stored = sessionMap.get(String(chatId));
     expect(stored.agentId).toBe('ag_new');
-    expect(stored.messageIds).not.toEqual(expect.arrayContaining([31, 32]));
+    const freshIds = messageIdsMap.get(String(chatId)) ?? [];
+    expect(freshIds).not.toEqual(expect.arrayContaining([31, 32]));
   });
 
   it('best-effort: a failing deleteMessage does not abort subsequent deletes', async () => {
@@ -494,8 +522,8 @@ describe('ephemeral setup-message cleanup', () => {
       step: 'awaiting_email',
       agentId: 'ag_test',
       pairingCode: 'ABCD1234',
-      messageIds: [41, 42, 43],
     });
+    messageIdsMap.set(String(chatId), [41, 42, 43]);
     (mockPrisma.pairingCode.findUnique as jest.Mock).mockResolvedValue({
       code: 'ABCD1234',
       agentId: 'ag_test',

--- a/tests/unit/telegram/signupHandler.test.ts
+++ b/tests/unit/telegram/signupHandler.test.ts
@@ -31,16 +31,22 @@ jest.mock('@/db/client', () => ({
 // Mock Telegram bot — sendMessage returns an incrementing message_id so tests
 // can assert which ids end up in the cleanup queue.
 let _mockMsgId = 100;
-const mockSendMessage = jest.fn().mockImplementation(() => Promise.resolve({ message_id: ++_mockMsgId }));
+const mockSendMessage = jest
+  .fn()
+  .mockImplementation(() => Promise.resolve({ message_id: ++_mockMsgId }));
 const mockDeleteMessage = jest.fn().mockResolvedValue(true);
 jest.mock('@/telegram/telegramClient', () => ({
-  getTelegramBot: () => ({ api: { sendMessage: mockSendMessage, deleteMessage: mockDeleteMessage } }),
+  getTelegramBot: () => ({
+    api: { sendMessage: mockSendMessage, deleteMessage: mockDeleteMessage },
+  }),
 }));
 
 // Mock session store — back the get/set with an in-memory map so the helpers
 // in signupHandler.ts (which read-modify-write the session) behave realistically.
 const sessionMap = new Map<string, any>();
-const mockGetSession = jest.fn(async (chatId: number | string) => sessionMap.get(String(chatId)) ?? null);
+const mockGetSession = jest.fn(
+  async (chatId: number | string) => sessionMap.get(String(chatId)) ?? null,
+);
 const mockSetSession = jest.fn(async (chatId: number | string, session: any) => {
   sessionMap.set(String(chatId), session);
 });
@@ -81,7 +87,9 @@ beforeEach(() => {
   _mockMsgId = 100;
   // Re-install the map-backed impls — earlier tests may have replaced them with
   // .mockResolvedValue(constant), and jest.clearAllMocks only clears calls, not impls.
-  mockGetSession.mockImplementation(async (cid: number | string) => sessionMap.get(String(cid)) ?? null);
+  mockGetSession.mockImplementation(
+    async (cid: number | string) => sessionMap.get(String(cid)) ?? null,
+  );
   mockSetSession.mockImplementation(async (cid: number | string, session: any) => {
     sessionMap.set(String(cid), session);
   });
@@ -408,9 +416,14 @@ describe('ephemeral setup-message cleanup', () => {
       messageIds: [11, 12, 13],
     });
     (mockPrisma.pairingCode.findUnique as jest.Mock).mockResolvedValue({
-      code: 'ABCD1234', agentId: 'ag_test', claimedByUserId: null,
+      code: 'ABCD1234',
+      agentId: 'ag_test',
+      claimedByUserId: null,
     });
-    (mockPrisma.user.create as jest.Mock).mockResolvedValue({ id: 'user-new', email: 'alice@example.com' });
+    (mockPrisma.user.create as jest.Mock).mockResolvedValue({
+      id: 'user-new',
+      email: 'alice@example.com',
+    });
     (mockPrisma.pairingCode.update as jest.Mock).mockResolvedValue({});
 
     await handleTelegramMessage(userMsg('alice@example.com', 14));
@@ -429,9 +442,14 @@ describe('ephemeral setup-message cleanup', () => {
       messageIds: [21, 22],
     });
     (mockPrisma.pairingCode.findUnique as jest.Mock).mockResolvedValue({
-      code: 'ABCD1234', agentId: 'ag_test', claimedByUserId: null,
+      code: 'ABCD1234',
+      agentId: 'ag_test',
+      claimedByUserId: null,
     });
-    (mockPrisma.user.create as jest.Mock).mockResolvedValue({ id: 'user-new', email: 'alice@example.com' });
+    (mockPrisma.user.create as jest.Mock).mockResolvedValue({
+      id: 'user-new',
+      email: 'alice@example.com',
+    });
     (mockPrisma.pairingCode.update as jest.Mock).mockResolvedValue({});
 
     await handleTelegramMessage(userMsg('alice@example.com', 23));
@@ -479,9 +497,14 @@ describe('ephemeral setup-message cleanup', () => {
       messageIds: [41, 42, 43],
     });
     (mockPrisma.pairingCode.findUnique as jest.Mock).mockResolvedValue({
-      code: 'ABCD1234', agentId: 'ag_test', claimedByUserId: null,
+      code: 'ABCD1234',
+      agentId: 'ag_test',
+      claimedByUserId: null,
     });
-    (mockPrisma.user.create as jest.Mock).mockResolvedValue({ id: 'user-new', email: 'alice@example.com' });
+    (mockPrisma.user.create as jest.Mock).mockResolvedValue({
+      id: 'user-new',
+      email: 'alice@example.com',
+    });
     (mockPrisma.pairingCode.update as jest.Mock).mockResolvedValue({});
 
     // Make the second delete reject


### PR DESCRIPTION
## Summary

Closes #163

The bot UX previously created a dual-channel feeling: setup/test pings mingled with live notifications, and the seeded demo user was auto-linked to a dev chat via `TELEGRAM_TEST_CHAT_ID`. A more recent change added `TELEGRAM_TEST_CHANNEL_ID` to route test traffic to a separate Telegram group — but the goal of #163 is the opposite: keep one chat per user and make setup messages disappear after onboarding completes.

This PR delivers:

- **Ephemeral setup messages.** During signup the bot tracks every message_id (its own + the user's `/start` and email reply) on the Redis signup session. On successful signup the bot sends the API-key message, then bulk-deletes the entire signup conversation and lands the user on the persistent main menu. Same cleanup runs when a stale session is replaced by a new `/start`. A `TELEGRAM_SETUP_CLEANED` audit event records the deleted count for observability after the chat is wiped.
- **Single onboarding path.** `TELEGRAM_TEST_CHAT_ID` is removed from `env.ts` / `seed.ts` (demo user is no longer auto-linked); `TELEGRAM_TEST_CHANNEL_ID` is removed entirely. Live integration tests still read `process.env.TELEGRAM_TEST_CHAT_ID` as a local-dev escape hatch and gracefully skip when unset.
- **Live test fixes** (surfaced while verifying the change):
  - `waitForCallback` filter compared `cb.from.id` against the configured chat ID — wrong in a group chat, where `from.id` is the tapping user's personal ID. Now compares `cb.message.chat.id`. Same fix in `menuHandler.live`.
  - Wrong-button alert no longer leaks raw `callback_data` identifiers; points to the instruction message instead.
- `deleteMessage` added to `mockBot`. New unit and e2e tests cover messageIds tracking, success-path cleanup, stale-session cleanup, audit event, and best-effort deletion. `docs/telegram-setup.md` rewritten around a single canonical `/start <code>` path with an ephemeral-messages note up top.

## Type of change

- [x] New feature
- [x] Refactor / cleanup
- [x] Tests only
- [x] Docs / config

## Module(s) affected

- [x] Contracts (`src/contracts/`)
- [x] DB / Prisma (`prisma/`, `src/db/`)
- [x] Telegram (`src/telegram/`)
- [x] Tests / QA
- [x] Docs / Tooling

## Checklist

- [x] `npm test` passes locally (376 unit tests; 2 pre-existing module-load failures on main unaffected)
- [x] New or changed logic has unit tests (`tests/unit/telegram/signupHandler.test.ts` — 5 new cases)
- [x] Integration tests added/updated (`tests/integration/e2e/onboarding.test.ts` — asserts cleanup + audit event)
- [x] No PAN, CVC, or card expiry is logged or stored
- [x] No new cross-module file edits
- [x] Types added/updated in `src/contracts/` (`AgentAuditEvent` gains `TELEGRAM_SETUP_CLEANED`)
- [x] `.env.example` updated (removed `TELEGRAM_TEST_CHAT_ID`)

## How to test

1. `docker compose up -d` (Postgres + Redis)
2. `npm run db:migrate && npm run seed` (creates `demo@agentpay.dev`, no chat auto-link)
3. `npm run dev`, register webhook per `docs/telegram-setup.md`
4. `POST /v1/agent/register` → grab pairing code → `/start <code>` in Telegram → Confirm → reply email
5. **Observe:** all setup messages (incl. the API-key one) disappear after signup; only the main menu remains
6. Trigger an approval flow (`POST /v1/intents` + `npm run worker`) — approval request stays (NOT deleted, that's intentional)
7. Live test verification (already done):
   - `npx jest --config jest.integration.live.js --testPathPattern=connectionFlow --forceExit` → 5/5 pass
   - `npx jest --config jest.integration.live.js --testPathPattern=preferences.live --forceExit --testTimeout=180000` → 12/12 pass interactively

## Notes for reviewer

- Removing `TELEGRAM_TEST_CHANNEL_ID` is intentional and reverses recent work; per the discussion on #163 the dual-channel split was the UX problem we're solving, not a feature to keep.
- `connectionFlow.test.ts` step 3.1 still skips gracefully if `TELEGRAM_TEST_CHAT_ID` is unset — no CI impact.
- Nothing on the live-test files changes their non-live (mocked) behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signup messages are sent ephemerally, tracked, bulk-deleted on success, and emit a TELEGRAM_SETUP_CLEANED audit event.

* **Documentation**
  * Telegram setup unified to a single onboarding flow using /start <code>; removed optional test chat/channel env entries.

* **Chores**
  * Example env and demo seed no longer include Telegram test chat/channel IDs.

* **Tests**
  * Mocks and integration/unit tests updated to cover message tracking, deleteMessage, and cleanup assertions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JonasBaeumer/AgentWallet/pull/164)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->