### PR TITLE
fix(security): mitigate polynomial ReDoS in email validation

### DIFF
--- a/src/telegram/signupHandler.ts
+++ b/src/telegram/signupHandler.ts
@@ -198,5 +198,6 @@ export async function handleTelegramMessage(update: Update): Promise<void> {
 }
 
 function isValidEmail(email: string): boolean {
-  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+  if (email.length > 254) return false;
+  return /^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$/.test(email);
 }


### PR DESCRIPTION
## Summary
- Fixes CodeQL alert [js/polynomial-redos #1](https://github.com/JonasBaeumer/AgentWallet/security/code-scanning/1) (high severity) on `src/telegram/signupHandler.ts`.
- The email validator regex `^[^\s@]+@[^\s@]+\.[^\s@]+$` ran on user-controlled Telegram message text. Because `[^\s@]` also matches `.`, the engine had multiple ways to align the literal `\.` against adversarial inputs like `!@!.!.!.!.…X`, leading to polynomial backtracking.
- Adds a 254-char length cap (RFC 5321) and rewrites the domain side as `[^\s@.]+(?:\.[^\s@.]+)+` so each dot-delimited segment excludes `.` and the boundary is unambiguous — match time is now linear in input length.

## Test plan
- [x] Existing `tests/unit/telegram/signupHandler.test.ts` suite passes (20/20) — covers `alice@example.com`, lowercase normalisation, and `not-an-email` rejection.
- [x] Manual sanity check against the regex:
  - Valid (`alice@example.com`, `demo@agentpay.dev`, `a.b@foo.co.uk`, `x@y.z`) → all match.
  - Invalid (`not-an-email`, `foo@bar`, `foo@.com`, `foo@bar.`, `@bar.com`, `foo bar@x.com`) → all rejected.
  - Adversarial `!@` + `!.` × N + ` ` (length 2 003 / 10 003 / 40 003) → 0.01 / 0.05 / 0.26 ms, linear scaling.
- [ ] CI green (lint, type-check, unit, integration).
- [ ] CodeQL re-scan closes alert #1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced email validation to support a broader range of valid email formats while enforcing industry-standard length limits.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JonasBaeumer/AgentWallet/pull/167)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->