### PR TITLE
fix(payments): use stripe/cjs resource types in reconciliationService

### DIFF
--- a/src/payments/providers/stripe/reconciliationService.ts
+++ b/src/payments/providers/stripe/reconciliationService.ts
@@ -1,4 +1,4 @@
-import Stripe from 'stripe';
+import type { Card, Transaction } from 'stripe/cjs/resources/Issuing';
 import { getStripeClient } from './stripeClient';
 import { prisma } from '@/db/client';
 import { logger } from '@/config/logger';
@@ -51,8 +51,8 @@ export async function reconcileIntent(intentId: string): Promise<ReconciliationR
   // Wrap the Stripe calls so a 404/429/network blip surfaces as a structured
   // discrepancy instead of an unhandled exception. The webhook caller's outer
   // catch already swallows throws silently — we want the audit trail.
-  let stripeCard: Stripe.Issuing.Card;
-  let transactions: Stripe.Issuing.Transaction[];
+  let stripeCard: Card;
+  let transactions: Transaction[];
   try {
     stripeCard = await stripe.issuing.cards.retrieve(card.providerCardId);
     transactions = await stripe.issuing.transactions


### PR DESCRIPTION
## Why
`main` fails `npx tsc --noEmit` after PRs #149 and #159 landed in parallel:

```
src/payments/providers/stripe/reconciliationService.ts(54,26): error TS2694:
  Namespace 'StripeConstructor' has no exported member 'Issuing'.
src/payments/providers/stripe/reconciliationService.ts(55,28): error TS2694:
  Namespace 'StripeConstructor' has no exported member 'Issuing'.
```

#149 added `Stripe.Issuing.Card` / `Stripe.Issuing.Transaction` annotations; #159 (Stripe 16 → 22) removed those namespace exports from the default `Stripe` import. Neither PR conflicted textually, but their semantic combination is broken on `main`.

## What
Switch to the same `stripe/cjs/resources/Issuing` resource-type imports that `cardService.ts`, `webhookHandler.ts`, and `checkoutSimulator.ts` already use post-Stripe 22. Drop the now-unused default `Stripe` import.

## Verification
- `npx tsc --noEmit` → clean
- `npx eslint src/payments/providers/stripe/reconciliationService.ts` → clean
- `npx jest --testPathIgnorePatterns=tests/integration` → 38 suites / 412 tests pass

No runtime behaviour change — types only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to payment reconciliation service with no changes to functionality or user-facing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JonasBaeumer/AgentWallet/pull/168)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->